### PR TITLE
Added book title and page number within chapter to the empty space when the nav is hidden.

### DIFF
--- a/src/BookView.ts
+++ b/src/BookView.ts
@@ -4,6 +4,7 @@ interface BookView {
 
     bookElement: Element;
     sideMargin: number;
+    height: number;
 
     /** Load this view in its book element, at the specified position. */
     start(position: number): void;

--- a/src/ColumnsPaginatedBookView.ts
+++ b/src/ColumnsPaginatedBookView.ts
@@ -125,7 +125,7 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
         return leftWidth / totalWidth;
     }
 
-    /** Returns the current 0-indexed page number. */
+    /** Returns the current 1-indexed page number. */
     public getCurrentPage(): number {
         return this.getCurrentPosition() * this.getPageCount() + 1;
     }

--- a/src/ColumnsPaginatedBookView.ts
+++ b/src/ColumnsPaginatedBookView.ts
@@ -6,6 +6,7 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
 
     public bookElement: HTMLIFrameElement;
     public sideMargin: number = 0;
+    public height: number = 0;
 
     public start(position: number): void {
         // any is necessary because CSSStyleDeclaration type does not include
@@ -34,10 +35,7 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
         // any is necessary because CSSStyleDeclaration type does not include
         // all the vendor-prefixed attributes.
         const body = this.bookElement.contentDocument.body as any;
-        const marginTop = parseInt((this.bookElement.style.marginTop || "0px").slice(0, -2));
-        const marginBottom = parseInt((this.bookElement.style.marginBottom || "0px").slice(0, -2));
 
-        const height = (window.innerHeight - marginTop - marginBottom) + "px";
         const width = (document.body.offsetWidth - this.sideMargin * 2) + "px"
         body.style.columnWidth = width;
         body.style.WebkitColumnWidth = width;
@@ -45,17 +43,17 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
         body.style.columnGap = this.sideMargin * 2 + "px";
         body.style.WebkitColumnGap = this.sideMargin * 2 + "px";
         body.style.MozColumnGap = this.sideMargin * 2 + "px";
-        body.style.height = height;
+        body.style.height = this.height + "px";
         body.style.width = width;
         body.style.marginLeft = this.sideMargin + "px";
         body.style.marginRight = this.sideMargin + "px";
-        this.bookElement.style.height = height;
+        this.bookElement.style.height = this.height + "px";
         this.bookElement.style.width = document.body.offsetWidth + "px";
 
         const images = body.querySelectorAll("img");
         for (const image of images) {
             image.style.maxWidth = width;
-            image.style.maxHeight = height;
+            image.style.maxHeight = this.height + "px";
         }
     }
 
@@ -125,6 +123,20 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
         const totalWidth = leftWidth + width + rightWidth;
 
         return leftWidth / totalWidth;
+    }
+
+    /** Returns the current 0-indexed page number. */
+    public getCurrentPage(): number {
+        return this.getCurrentPosition() * this.getPageCount() + 1;
+    }
+
+    /** Returns the total number of pages. */
+    public getPageCount(): number {
+        const width = this.getColumnWidth();
+        const leftWidth = this.getLeftColumnsWidth();
+        const rightWidth = this.getRightColumnsWidth();
+        const totalWidth = leftWidth + width + rightWidth;
+        return totalWidth / width;
     }
 
     public onFirstPage(): boolean {

--- a/src/Manifest.ts
+++ b/src/Manifest.ts
@@ -78,6 +78,14 @@ export default class Manifest {
         return null;
     }
 
+    public getSpineItem(href: string): Link | null {
+        const index = this.getSpineIndex(href);
+        if (index !== null) {
+            return this.spine[index];
+        }
+        return null;
+    }
+
     private getSpineIndex(href: string): number | null {
         for (let index = 0; index < this.spine.length; index++) {
             const item = this.spine[index];

--- a/src/PaginatedBookView.ts
+++ b/src/PaginatedBookView.ts
@@ -5,5 +5,7 @@ interface PaginatedBookView extends BookView {
     onLastPage(): boolean;
     goToPreviousPage(): void;
     goToNextPage(): void;
+    getCurrentPage(): number;
+    getPageCount(): number;
 }
 export default PaginatedBookView;

--- a/src/ScrollingBookView.ts
+++ b/src/ScrollingBookView.ts
@@ -6,19 +6,17 @@ export default class ScrollingBookView implements BookView {
 
     public bookElement: HTMLIFrameElement;
     public sideMargin: number = 0;
+    public height: number = 0;
 
     private setIFrameSize(): void {
         // Remove previous iframe height so body scroll height will be accurate.
         this.bookElement.style.height = "";
 
-        const marginTop = parseInt((this.bookElement.style.marginTop || "0px").slice(0, -2));
-        const marginBottom = parseInt((this.bookElement.style.marginBottom || "0px").slice(0, -2));
-
         this.bookElement.style.width = (document.body.offsetWidth - this.sideMargin * 2) + "px";
         this.bookElement.style.marginLeft = this.sideMargin + "px";
         this.bookElement.style.marginRight = this.sideMargin + "px";
 
-        const minHeight = (window.innerHeight - marginTop - marginBottom);
+        const minHeight = this.height;
         const bodyHeight = this.bookElement.contentDocument.body.scrollHeight;
         this.bookElement.style.height = Math.max(minHeight, bodyHeight) + "px";
     }

--- a/src/styles/sass/main.scss
+++ b/src/styles/sass/main.scss
@@ -208,5 +208,21 @@ a {
   }
 // /controls-view
 
+// /info
+.info {
+  text-align: center;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  color: $nypl-blue-dark;
+  margin: 0 1.5rem;
+  &.top {
+    line-height: 3rem;
+  }
+  &.bottom {
+    line-height: 2rem;
+  }
+}
+
 @import "toc";
 @import "settings";

--- a/test/BookSettingsTest.ts
+++ b/test/BookSettingsTest.ts
@@ -18,6 +18,7 @@ describe("BookSettings", () => {
         public label: string;
         public bookElement: Element;
         public sideMargin: number;
+        public height: number;
         public constructor(id: number, name: string, label: string) {
             this.id = id;
             this.name = name;

--- a/test/ColumnsPaginatedBookViewTests.ts
+++ b/test/ColumnsPaginatedBookViewTests.ts
@@ -4,8 +4,7 @@ import ColumnsPaginatedBookView from "../src/ColumnsPaginatedBookView";
 
 describe("ColumnsPaginatedBookView", () => {
     let iframe: HTMLIFrameElement;
-    let topMargin: number = 10;
-    let bottomMargin: number = 20;
+    let height: number = 200;
     let sideMargin: number = 11;
     let paginator: ColumnsPaginatedBookView;
 
@@ -17,8 +16,7 @@ describe("ColumnsPaginatedBookView", () => {
         paginator = new ColumnsPaginatedBookView();
         paginator.bookElement = iframe;
         paginator.sideMargin = sideMargin;
-        iframe.style.marginTop = topMargin + "px";
-        iframe.style.marginBottom = bottomMargin + "px";
+        paginator.height = height;
     });
 
     describe("#start", () => {
@@ -32,8 +30,7 @@ describe("ColumnsPaginatedBookView", () => {
             expect(body.style.position).to.equal("relative");
         });
 
-        it("should set iframe and iframe body width and height and column width based on window size and iframe margins", () => {
-            (window as any).innerHeight = 230;
+        it("should set iframe and iframe body width and height and column width based on window width and set height", () => {
             (document.body as any).offsetWidth = 100;
             paginator.start(0);
             const body = iframe.contentDocument.body;
@@ -46,7 +43,6 @@ describe("ColumnsPaginatedBookView", () => {
         });
 
         it("should set max width and height on image in iframe", () => {
-            (window as any).innerHeight = 230;
             (document.body as any).offsetWidth = 100;
             const body = iframe.contentDocument.body;
             const image  = window.document.createElement("img");
@@ -119,6 +115,74 @@ describe("ColumnsPaginatedBookView", () => {
             (iframe.contentDocument.body as any).scrollWidth = 111;
 
             expect(paginator.getCurrentPosition()).to.equal(0.75);
+        });
+    });
+
+    describe("#getCurrentPage", () => {
+        it("should get first page", () => {
+            paginator.start(0);
+
+            iframe.contentDocument.body.style.left = "0px";
+            (iframe.contentDocument.body as any).offsetWidth = 100;
+            (iframe.contentDocument.body as any).scrollWidth = 477;
+
+            expect(paginator.getCurrentPage()).to.equal(1);
+        });
+
+        it("should get middle page", () => {
+            paginator.start(0);
+
+            iframe.contentDocument.body.style.left = "-122px";
+            (iframe.contentDocument.body as any).offsetWidth = 100;
+            (iframe.contentDocument.body as any).scrollWidth = 355;
+
+            expect(paginator.getCurrentPage()).to.equal(2);
+
+            iframe.contentDocument.body.style.left = "-244px";
+            (iframe.contentDocument.body as any).scrollWidth = 233;
+            expect(paginator.getCurrentPage()).to.equal(3);
+        });
+
+        it("should get last page", () => {
+            paginator.start(0);
+
+            iframe.contentDocument.body.style.left = "-366px";
+            (iframe.contentDocument.body as any).offsetWidth = 100;
+            (iframe.contentDocument.body as any).scrollWidth = 111;
+
+            expect(paginator.getCurrentPage()).to.equal(4);
+        });
+    });
+
+    describe("#getPageCount", () => {
+        it("should work on first page", () => {
+            paginator.start(0);
+
+            iframe.contentDocument.body.style.left = "0px";
+            (iframe.contentDocument.body as any).offsetWidth = 100;
+            (iframe.contentDocument.body as any).scrollWidth = 477;
+
+            expect(paginator.getPageCount()).to.equal(4);
+        });
+
+        it("should work on middle page", () => {
+            paginator.start(0);
+
+            iframe.contentDocument.body.style.left = "-122px";
+            (iframe.contentDocument.body as any).offsetWidth = 100;
+            (iframe.contentDocument.body as any).scrollWidth = 355;
+
+            expect(paginator.getPageCount()).to.equal(4);
+        });
+
+        it("should work on last page", () => {
+            paginator.start(0);
+
+            iframe.contentDocument.body.style.left = "-366px";
+            (iframe.contentDocument.body as any).offsetWidth = 100;
+            (iframe.contentDocument.body as any).scrollWidth = 111;
+
+            expect(paginator.getPageCount()).to.equal(4);
         });
     });
 

--- a/test/ManifestTests.ts
+++ b/test/ManifestTests.ts
@@ -171,5 +171,22 @@ describe("Manifest", () => {
             expect(next).to.be.null;
         });
     });
+
+    describe("#getSpineItem", () => {
+        it("should return correct spine item", () => {
+            let item = manifest.getSpineItem("http://example.com/spine-item-1.html") as Link;
+            expect(item).not.to.be.null;
+            expect(item.href).to.equal("spine-item-1.html");
+
+            item = manifest.getSpineItem("http://example.com/spine-item-2.html") as Link;
+            expect(item).not.to.be.null;
+            expect(item.href).to.equal("spine-item-2.html");
+        });
+
+        it("should return null for item not in the spine", () => {
+            const item = manifest.getSpineItem("http://example.com/toc.html");
+            expect(item).to.be.null;
+        });
+    });
 });
 

--- a/test/ScrollingBookViewTests.ts
+++ b/test/ScrollingBookViewTests.ts
@@ -31,9 +31,7 @@ describe("ScrollingBookView", () => {
 
         it("should set iframe size", () => {
             scroller.sideMargin = 11;
-            (window as any).innerHeight = 100;
-            iframe.style.marginTop = "10px";
-            iframe.style.marginBottom = "20px";
+            scroller.height = 70;
             (iframe.contentDocument.body as any).scrollHeight = 200;
             (document.body as any).offsetWidth = 50;
 
@@ -57,7 +55,7 @@ describe("ScrollingBookView", () => {
 
     describe("#stop", () => {
         it("should remove styling from iframe", () => {
-            (window as any).innerHeight = 100;
+            scroller.height = 100;
             (iframe.contentDocument.body as any).scrollHeight = 200;
             scroller.start(0);
 


### PR DESCRIPTION
This fixes #27. 

Demo: http://dev-mta.librarysimplified.org/examples/alice/

The top has the book title, and the bottom has "Page X of Y (chapter title)"

The chapter title will say "Chapter" if the spine item in the epub doesn't have a chapter title, same as our mobile apps. 