### PR TITLE
Within book link handling

### DIFF
--- a/src/BookView.ts
+++ b/src/BookView.ts
@@ -14,5 +14,6 @@ interface BookView {
 
     getCurrentPosition(): number;
     goToPosition(position: number): void;
+    goToElement(elementId: string): void;
 }
 export default BookView;

--- a/src/ColumnsPaginatedBookView.ts
+++ b/src/ColumnsPaginatedBookView.ts
@@ -192,4 +192,17 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
         }
         this.setLeftColumnsWidth(roundedLeftWidth);
     }
+
+    public goToElement(elementId: string) {
+        const element = this.bookElement.contentDocument.getElementById(elementId);
+        if (element) {
+            // Get the element's position in the iframe, and
+            // round that to figure out the column it's in.
+
+            const left = element.getBoundingClientRect().left;
+            const width = this.getColumnWidth();
+            const roundedLeftWidth = Math.floor(left / width) * width;
+            this.setLeftColumnsWidth(roundedLeftWidth);
+        }
+    }
 }

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -524,7 +524,13 @@ export default class IFrameNavigator implements Navigator {
         this.iframe.contentDocument.body.style.fontSize = fontSize;
         this.iframe.contentDocument.body.style.lineHeight = "1.5";
 
-        const sideMargin = parseInt(fontSize.slice(0, -2)) * 2;
+        const fontSizeNumber = parseInt(fontSize.slice(0, -2));
+        let sideMargin = fontSizeNumber * 2;
+
+        if (window.innerWidth > fontSizeNumber * 45) {
+            const extraMargin = Math.floor((window.innerWidth - fontSizeNumber * 40) / 2);
+            sideMargin = sideMargin + extraMargin;
+        }
         if (this.paginator) {
             this.paginator.sideMargin = sideMargin;
         }

--- a/src/ScrollingBookView.ts
+++ b/src/ScrollingBookView.ts
@@ -40,4 +40,18 @@ export default class ScrollingBookView implements BookView {
         this.setIFrameSize();
         document.body.scrollTop = document.body.scrollHeight * position;
     }
+
+    public goToElement(elementId: string) {
+        const element = this.bookElement.contentDocument.getElementById(elementId);
+        if (element) {
+            // Put the element as close to the top as possible.
+            element.scrollIntoView();
+
+            // Unless we're already at the bottom, scroll up so the element is
+            // in the middle, and not covered by the top nav.
+            if ((document.body.scrollHeight - element.offsetTop) >= this.height) {
+                document.body.scrollTop = Math.max(0, document.body.scrollTop - this.height / 3);
+            }
+        }
+    }
 }

--- a/src/styles/sass/main.scss
+++ b/src/styles/sass/main.scss
@@ -13,10 +13,6 @@ body {
   font-size: $basefont;
   margin: 0 auto;
   overflow: hidden;
-
-  @media (min-width: 45rem) {
-    width: 40rem;
-  }
 }
 
 ul li {

--- a/test/BookSettingsTest.ts
+++ b/test/BookSettingsTest.ts
@@ -36,6 +36,7 @@ describe("BookSettings", () => {
         public goToPosition(position: number) {
             goToPosition(this.id, position);
         }
+        public goToElement() {}
     }
 
     let view1: MockBookView;

--- a/test/ColumnsPaginatedBookViewTests.ts
+++ b/test/ColumnsPaginatedBookViewTests.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import { stub } from "sinon";
 
 import ColumnsPaginatedBookView from "../src/ColumnsPaginatedBookView";
 
@@ -305,6 +306,64 @@ describe("ColumnsPaginatedBookView", () => {
 
             paginator.goToPosition(0.3);
             expect(iframe.contentDocument.body.style.left).to.equal("-122px");
+        });
+    });
+
+    describe("#goToElement", () => {
+        it("should do nothing if element doesn't exist", () => {
+            paginator.start(0);
+            iframe.contentDocument.body.style.left = "-20px";
+            paginator.goToElement("not-an-element");
+            expect(iframe.contentDocument.body.style.left).to.equal("-20px");
+        });
+
+        it("should go to element on first page", () => {
+            paginator.start(0);
+
+            const element = document.createElement("a");
+            element.id = "element";
+            element.getBoundingClientRect = stub().returns({ left: 5 });
+            iframe.contentDocument.body.appendChild(element);
+            iframe.contentDocument.body.style.left = "-122px";
+            (iframe.contentDocument.body as any).offsetWidth = 100;
+            (iframe.contentDocument.body as any).scrollWidth = 355;
+
+            paginator.goToElement("element");
+            expect(iframe.contentDocument.body.style.left).to.equal("0px");
+        });
+
+        it("should go to element on middle page", () => {
+            paginator.start(0);
+
+            const element = document.createElement("a");
+            element.id = "element";
+            element.getBoundingClientRect = stub().returns({ left: 150 });
+            iframe.contentDocument.body.appendChild(element);
+            iframe.contentDocument.body.style.left = "0px";
+            (iframe.contentDocument.body as any).offsetWidth = 100;
+            (iframe.contentDocument.body as any).scrollWidth = 477;
+
+            paginator.goToElement("element");
+            expect(iframe.contentDocument.body.style.left).to.equal("-122px");
+
+            element.getBoundingClientRect = stub().returns({ left: 250 });
+            paginator.goToElement("element");
+            expect(iframe.contentDocument.body.style.left).to.equal("-244px");
+        });
+
+        it("should go to element on last page", () => {
+            paginator.start(0);
+
+            const element = document.createElement("a");
+            element.id = "element";
+            element.getBoundingClientRect = stub().returns({ left: 450 });
+            iframe.contentDocument.body.appendChild(element);
+            iframe.contentDocument.body.style.left = "0px";
+            (iframe.contentDocument.body as any).offsetWidth = 100;
+            (iframe.contentDocument.body as any).scrollWidth = 477;
+
+            paginator.goToElement("element");
+            expect(iframe.contentDocument.body.style.left).to.equal("-366px");
         });
     });
 });

--- a/test/IFrameNavigatorTests.ts
+++ b/test/IFrameNavigatorTests.ts
@@ -27,6 +27,7 @@ describe("IFrameNavigator", () => {
     let goToPreviousPage: Sinon.SinonStub;
     let goToNextPage: Sinon.SinonStub;
     let paginatorGoToPosition: Sinon.SinonStub;
+    let paginatorGoToElement: Sinon.SinonStub;
     let paginatorCurrentPage: number;
     let paginator: PaginatedBookView;
 
@@ -79,6 +80,12 @@ describe("IFrameNavigator", () => {
         public getCurrentPosition() {
             return 0.25;
         }
+        public getCurrentPage() {
+            return paginatorCurrentPage;
+        }
+        public getPageCount() {
+            return 8;
+        }
         public onFirstPage() {
             return onFirstPage();
         }
@@ -94,11 +101,8 @@ describe("IFrameNavigator", () => {
         public goToPosition(position: number) {
             paginatorGoToPosition(position);
         }
-        public getCurrentPage() {
-            return paginatorCurrentPage;
-        }
-        public getPageCount() {
-            return 8;
+        public goToElement(elementId: string) {
+            paginatorGoToElement(elementId);
         }
     }
 
@@ -193,6 +197,7 @@ describe("IFrameNavigator", () => {
         goToPreviousPage = stub();
         goToNextPage = stub();
         paginatorGoToPosition = stub();
+        paginatorGoToElement = stub();
         paginatorCurrentPage = 2;
         paginator = new MockPaginator();
 
@@ -413,6 +418,22 @@ describe("IFrameNavigator", () => {
             expect(saveLastReadingPosition.callCount).to.equal(1);
             expect(saveLastReadingPosition.args[0][0]).to.deep.equal({
                 resource: "http://example.com/start.html",
+                position: 0.25
+            });
+        });
+
+        it("should navigate to an element from the iframe src", async () => {
+            const iframe = element.querySelector("iframe") as HTMLIFrameElement;
+            iframe.src = "http://example.com/item-1.html#element";
+
+            await pause();
+            expect(iframe.src).to.equal("http://example.com/item-1.html");
+            expect(paginatorGoToElement.callCount).to.equal(1);
+            expect(paginatorGoToElement.args[0][0]).to.equal("element");
+
+            expect(saveLastReadingPosition.callCount).to.equal(2);
+            expect(saveLastReadingPosition.args[1][0]).to.deep.equal({
+                resource: "http://example.com/item-1.html",
                 position: 0.25
             });
         });

--- a/test/IFrameNavigatorTests.ts
+++ b/test/IFrameNavigatorTests.ts
@@ -331,13 +331,17 @@ describe("IFrameNavigator", () => {
         });
 
         it("should give the settings a function to call when the font size changes", async () => {
+            // If the window is wide enough, the view gets a large margin.
+            // This is what jsdom sets the window width to by default.
+            expect(window.innerWidth).to.equal(1024);
+
             expect(onFontSizeChange.callCount).to.equal(1);
             const iframe = element.querySelector("iframe") as HTMLIFrameElement;
 
             await pause();
             expect(iframe.contentDocument.body.style.fontSize).to.equal("14px");
             expect(iframe.contentDocument.body.style.lineHeight).to.equal("1.5");
-            expect(paginator.sideMargin).to.equal(28);
+            expect(paginator.sideMargin).to.equal(260);
 
             const updateFontSize = onFontSizeChange.args[0][0];
 
@@ -346,8 +350,25 @@ describe("IFrameNavigator", () => {
 
             expect(iframe.contentDocument.body.style.fontSize).to.equal("16px");
             expect(iframe.contentDocument.body.style.lineHeight).to.equal("1.5");
-            expect(paginator.sideMargin).to.equal(32);
+            expect(paginator.sideMargin).to.equal(224);
             expect(paginatorGoToPosition.callCount).to.equal(2);
+
+            // If the window is small, the view gets a smaller margin, but still based
+            // on the font size.
+            (window as any).innerWidth = 100;
+
+            getSelectedFontSize.returns("14px");
+            updateFontSize();
+            expect(iframe.contentDocument.body.style.fontSize).to.equal("14px");
+            expect(iframe.contentDocument.body.style.lineHeight).to.equal("1.5");
+            expect(paginator.sideMargin).to.equal(28);
+
+            getSelectedFontSize.returns("16px");
+            updateFontSize();
+
+            expect(iframe.contentDocument.body.style.fontSize).to.equal("16px");
+            expect(iframe.contentDocument.body.style.lineHeight).to.equal("1.5");
+            expect(paginator.sideMargin).to.equal(32);
         });
 
         it("should give the settings a function to call when offline is enabled", () => {

--- a/test/ScrollingBookViewTests.ts
+++ b/test/ScrollingBookViewTests.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import { stub } from "sinon";
 
 import ScrollingBookView from "../src/ScrollingBookView";
 
@@ -134,6 +135,63 @@ describe("ScrollingBookView", () => {
 
             scroller.goToPosition(1);
             expect(document.body.scrollTop).to.equal(200);
+        });
+    });
+
+    describe("#goToElement", () => {
+        it("should do nothing if element doesn't exist", () => {
+            scroller.start(0);
+            document.body.scrollTop = 100;
+            scroller.goToElement("not-an-element");
+            expect(document.body.scrollTop).to.equal(100);
+        });
+
+        it("should go to element at the top", () => {
+            scroller.height = 50;
+            scroller.start(0);
+            const element = document.createElement("a");
+            element.scrollIntoView = stub();
+            element.id = "element";
+            iframe.contentDocument.body.appendChild(element);
+            
+            document.body.scrollTop = 0;
+            (document.body as any).scrollHeight = 200;
+            (element as any).offsetTop = 100;
+
+            scroller.goToElement("element");
+            expect(document.body.scrollTop).to.equal(0);
+        });
+
+        it("should go to element in the middle", () => {
+            scroller.height = 75;
+            scroller.start(0);
+            const element = document.createElement("a");
+            element.scrollIntoView = stub();
+            element.id = "element";
+            iframe.contentDocument.body.appendChild(element);
+            
+            document.body.scrollTop = 50;
+            (document.body as any).scrollHeight = 200;
+            (element as any).offsetTop = 100;
+
+            scroller.goToElement("element");
+            expect(document.body.scrollTop).to.equal(25);
+        });
+
+        it("should go to element at the bottom", () => {
+            scroller.height = 50;
+            scroller.start(0);
+            const element = document.createElement("a");
+            element.scrollIntoView = stub();
+            element.id = "element";
+            iframe.contentDocument.body.appendChild(element);
+            
+            document.body.scrollTop = 150;
+            (document.body as any).scrollHeight = 200;
+            (element as any).offsetTop = 175;
+
+            scroller.goToElement("element");
+            expect(document.body.scrollTop).to.equal(150);
         });
     });
 });


### PR DESCRIPTION
This fixes #21.

When you click a link that goes to an element in one of the chapters of the book, it sends you to a page or scroll position so that the element is visible.

The way I did this is a little messy - when a link goes to a new chapter, the iframe loads what it thinks the position should be, then we remove that and send you to the beginning of the chapter, then we send you to the element. It makes the page jump around for a second, but you end up in the right place. I'm going to create a couple more issues and come back to this later. Not many of our books have footnotes/endnotes so it's not a huge problem yet.

While I was doing this I noticed that some of the css for large screens was breaking my logic for figuring out when you clicked a link, so I had to change that so it sets a larger margin in js instead of setting the body width in css.

Here's a demo book with endnotes: http://dev-mta.librarysimplified.org/examples/twenty/
(The TOC is a little messed up, but that's an issue with the code that sets up the book, not the reader)

