### PR TITLE
Gesture handling in iframe

### DIFF
--- a/src/ColumnsPaginatedBookView.ts
+++ b/src/ColumnsPaginatedBookView.ts
@@ -9,6 +9,14 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
     public height: number = 0;
 
     public start(position: number): void {
+        document.body.style.overflow = "hidden";
+        // This prevents overscroll/bouncing on iOS.
+        document.body.style.position = "fixed";
+        document.body.style.left = "0";
+        document.body.style.right = "0";
+        document.body.style.top = "0";
+        document.body.style.bottom = "0";
+
         // any is necessary because CSSStyleDeclaration type does not include
         // all the vendor-prefixed attributes.
         const body = this.bookElement.contentDocument.body as any;
@@ -58,6 +66,13 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
     }
 
     public stop(): void {
+        document.body.style.overflow = "scroll";
+        document.body.style.position = "static";
+        document.body.style.left = "";
+        document.body.style.right = "";
+        document.body.style.top = "";
+        document.body.style.bottom = "";
+
         const body = this.bookElement.contentDocument.body as any;
         body.style.columnCount = "";
         body.style.WebkitColumnCount = "";

--- a/src/EventHandler.ts
+++ b/src/EventHandler.ts
@@ -217,15 +217,12 @@ export default class EventHandler {
     }
 
     private checkForLink = (event: MouseEvent | TouchEvent): boolean => {
-        const target = event.target;
-        if (target instanceof Element) {
-            let nextElement = event.target as Element;
-            while (nextElement && nextElement.tagName.toLowerCase() !== "body") {
-                if (nextElement.tagName.toLowerCase() === "a") {
-                    return true;
-                } else {
-                    nextElement = nextElement.parentElement;
-                }
+        let nextElement = event.target as Element;
+        while (nextElement && nextElement.tagName.toLowerCase() !== "body") {
+            if (nextElement.tagName.toLowerCase() === "a") {
+                return true;
+            } else {
+                nextElement = nextElement.parentElement;
             }
         }
         return false;

--- a/src/EventHandler.ts
+++ b/src/EventHandler.ts
@@ -1,0 +1,248 @@
+export default class EventHandler {
+    private pendingMouseEventStart: MouseEvent | null;
+    private pendingMouseEventEnd: MouseEvent | null;
+    private pendingTouchEventStart: TouchEvent | null;
+    private pendingTouchEventEnd: TouchEvent | null;
+
+    public onLeftTap: (event: UIEvent) => void = () => {};
+    public onMiddleTap: (event: UIEvent) => void = () => {};
+    public onRightTap: (event: UIEvent) => void = () => {};
+    public onBackwardSwipe: (event: UIEvent) => void = () => {};
+    public onForwardSwipe: (event: UIEvent) => void = () => {};
+
+    public onLeftHover: () => void = () => {};
+    public onRightHover: () => void = () => {};
+    public onRemoveHover: () => void = () => {};
+
+    public constructor() {
+        this.pendingMouseEventStart = null;
+        this.pendingMouseEventEnd = null;
+        this.pendingTouchEventStart = null;
+        this.pendingTouchEventEnd = null;
+    }
+
+    public setupEvents(element: HTMLElement | Document) {
+        if (this.isTouchDevice()) {
+            element.addEventListener("touchstart", this.handleTouchEventStart.bind(this));
+            element.addEventListener("touchend", this.handleTouchEventEnd.bind(this));
+        } else {
+            element.addEventListener("mousedown", this.handleMouseEventStart.bind(this));
+            element.addEventListener("mouseup", this.handleMouseEventEnd.bind(this));
+            element.addEventListener("mouseenter", this.handleMouseMove.bind(this));
+            element.addEventListener("mousemove", this.handleMouseMove.bind(this));
+            element.addEventListener("mouseleave", this.handleMouseLeave.bind(this));
+        }
+    }
+
+    private isTouchDevice() {
+        return !!('ontouchstart' in window || navigator.maxTouchPoints);
+    }
+
+    private handleMouseEventStart = (event: MouseEvent): void => {
+        this.pendingMouseEventStart = event;
+    }
+
+    private handleTouchEventStart = (event: TouchEvent): void => {
+        if (event.changedTouches.length !== 1) {
+            // This is a multi-touch event. Ignore.
+            return;
+        }
+
+        this.pendingTouchEventStart = event;
+    }
+
+    private handleMouseEventEnd = (event: MouseEvent): void => {
+        if (!this.pendingMouseEventStart) {
+            // Somehow we got an end event without a start event. Ignore it.
+            return;
+        }
+
+        const width = window.innerWidth;
+        const height = window.innerHeight;
+
+        const relativeXDistance = (this.pendingMouseEventStart.clientX - event.clientX) / width;
+        const relativeYDistance = (this.pendingMouseEventStart.clientY - event.clientY) / height;
+
+        // Is the end event in the same place as the start event?
+        if (Math.abs(relativeXDistance) < 0.1 && Math.abs(relativeYDistance) < 0.1) {
+            if (this.pendingMouseEventEnd) {
+                // This was a double click. Let the browser handle it.
+                this.pendingMouseEventStart = null;
+                this.pendingMouseEventEnd = null;
+                return;
+            }
+
+            // This was a single click.
+            this.pendingMouseEventStart = null;
+            this.pendingMouseEventEnd = event;
+            setTimeout(this.handleClick, 200);
+            return;
+        }
+
+        this.pendingMouseEventEnd = null;
+
+        // This is a swipe or highlight. Let the browser handle it.
+        // (Swipes aren't handled on desktop.)
+        this.pendingMouseEventStart = null;
+    }
+
+    private handleTouchEventEnd = (event: TouchEvent): void => {
+        if (event.changedTouches.length !== 1) {
+            // This is a multi-touch event. Ignore.
+            return;
+        }
+
+        if (!this.pendingTouchEventStart) {
+            // Somehow we got an end event without a start event. Ignore it.
+            return;
+        }
+
+        const width = window.innerWidth;
+        const height = window.innerHeight;
+
+        const startTouch = this.pendingTouchEventStart.changedTouches[0];
+        const endTouch = event.changedTouches[0];
+
+        if (!startTouch) {
+            // Somehow we saved a touch event with no touches.
+            return;
+        }
+
+        const relativeXDistance = (startTouch.clientX - endTouch.clientX) / width;
+        const relativeYDistance = (startTouch.clientY - endTouch.clientY) / height;
+
+        // Is the end event in the same place as the start event?
+        if (Math.abs(relativeXDistance) < 0.1 && Math.abs(relativeYDistance) < 0.1) {
+            if (this.pendingTouchEventEnd) {
+                // This was a double tap. Let the browser handle it.
+                this.pendingTouchEventStart = null;
+                this.pendingTouchEventEnd = null;
+                return;
+            }
+
+            // This was a single tap or long press.
+            if (event.timeStamp - this.pendingTouchEventStart.timeStamp > 500) {
+                // This was a long press. Let the browser handle it.
+                this.pendingTouchEventStart = null;
+                this.pendingTouchEventEnd = null;
+                return;
+            }
+
+            // This was a single tap.
+            this.pendingTouchEventStart = null;
+            this.pendingTouchEventEnd = event;
+            setTimeout(this.handleTap, 200);
+            return;
+        }
+
+        this.pendingTouchEventEnd = null;
+
+        if (event.timeStamp - this.pendingTouchEventStart.timeStamp > 500) {
+            // This is a slow swipe / highlight. Let the browser handle it.
+            this.pendingTouchEventStart = null;
+            return;
+        }
+
+        // This is a swipe. 
+        const slope = (startTouch.clientY - endTouch.clientY) / (startTouch.clientX - endTouch.clientX);
+        if (Math.abs(slope) > 0.5) {
+            // This is a mostly vertical swipe. Ignore.
+            this.pendingTouchEventStart = null;
+            return;
+        }
+
+        // This was a horizontal swipe.
+        if (relativeXDistance < 0) {
+            this.onBackwardSwipe(event);
+        } else {
+            this.onForwardSwipe(event);
+        }
+        this.pendingTouchEventStart = null;
+    }
+
+    private handleClick = (): void => {
+        if (!this.pendingMouseEventEnd) {
+            // Another click happened already.
+            return;
+        }
+
+        if (this.checkForLink(this.pendingMouseEventEnd)) {
+            // This was a single click on a link. Do nothing.
+            this.pendingMouseEventEnd = null;
+            return;
+        }
+
+        // This was a single click.
+        const x = this.pendingMouseEventEnd.clientX;
+        const width = window.innerWidth;
+        if (x / width < 0.3) {
+            this.onLeftTap(this.pendingMouseEventEnd);
+        } else if (x / width > 0.7) {
+            this.onRightTap(this.pendingMouseEventEnd);
+        } else {
+            this.onMiddleTap(this.pendingMouseEventEnd);
+        }
+        this.pendingMouseEventEnd = null;
+        return;
+    }
+
+    private handleTap = (): void => {
+        if (!this.pendingTouchEventEnd) {
+            // Another tap happened already.
+            return;
+        }
+
+        if (this.checkForLink(this.pendingTouchEventEnd)) {
+            // This was a single tap on a link. Do nothing.
+            this.pendingTouchEventEnd = null;
+            return;
+        }
+
+        // This was a single tap.
+        const touch = this.pendingTouchEventEnd.changedTouches[0];
+        if (!touch) {
+            // Somehow we got a touch event with no touches.
+            return;
+        }
+
+        const x = touch.clientX;
+        const width = window.innerWidth;
+        if (x / width < 0.3) {
+            this.onLeftTap(this.pendingTouchEventEnd);
+        } else if (x / width > 0.7) {
+            this.onRightTap(this.pendingTouchEventEnd);
+        } else {
+            this.onMiddleTap(this.pendingTouchEventEnd);
+        }
+        this.pendingTouchEventEnd = null;
+        return;
+    }
+
+    private checkForLink = (event: MouseEvent | TouchEvent): boolean => {
+        let nextElement = event.target as Element;
+        while (nextElement && nextElement.tagName.toLowerCase() !== "body") {
+            if (nextElement.tagName.toLowerCase() === "a") {
+                return true;
+            } else {
+                nextElement = nextElement.parentElement;
+            }
+        }
+        return false;
+    }
+
+    private handleMouseMove = (event: MouseEvent): void => {
+        const x = event.clientX;
+        const width = window.innerWidth;
+        if (x / width < 0.3) {
+            this.onLeftHover();
+        } else if (x / width > 0.7) {
+            this.onRightHover();
+        } else {
+            this.onRemoveHover();
+        }
+    }
+
+    private handleMouseLeave = (): void => {
+        this.onRemoveHover();
+    }
+}

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -576,8 +576,8 @@ export default class IFrameNavigator implements Navigator {
 
     private updatePositionInfo() {
         if (this.settings.getSelectedView() === this.paginator) {
-            const currentPage = this.paginator.getCurrentPage();
-            const pageCount = this.paginator.getPageCount();
+            const currentPage = Math.round(this.paginator.getCurrentPage());
+            const pageCount = Math.round(this.paginator.getPageCount());
             this.chapterPosition.innerHTML = "Page " + currentPage + " of " + pageCount;
         } else {
             this.chapterPosition.innerHTML = "";

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -213,13 +213,6 @@ export default class IFrameNavigator implements Navigator {
         const doNothing = () => {};
         if (this.settings.getSelectedView() === this.paginator) {
             document.body.onscroll = () => {};
-            document.body.style.overflow = "hidden";
-            // This prevents overscroll/bouncing on iOS.
-            document.body.style.position = "fixed";
-            document.body.style.left = "0";
-            document.body.style.right = "0";
-            document.body.style.top = "0";
-            document.body.style.bottom = "0";
             this.chapterTitle.style.display = "inline";
             this.chapterPosition.style.display = "inline";
             if (this.eventHandler) {
@@ -234,12 +227,6 @@ export default class IFrameNavigator implements Navigator {
             }
         } else if (this.settings.getSelectedView() === this.scroller) {
             document.body.onscroll = this.saveCurrentReadingPosition.bind(this);
-            document.body.style.overflow = "scroll";
-            document.body.style.position = "static";
-            document.body.style.left = "";
-            document.body.style.right = "";
-            document.body.style.top = "";
-            document.body.style.bottom = "";
             this.chapterTitle.style.display = "none";
             this.chapterPosition.style.display = "none";
             if (this.eventHandler) {

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -103,7 +103,7 @@ export default class IFrameNavigator implements Navigator {
     private scroller: ScrollingBookView | null;
     private annotator: Annotator | null;
     private settings: BookSettings;
-    private eventHandler: EventHandler | null;
+    private eventHandler: EventHandler;
     private iframe: HTMLIFrameElement;
     private nextChapterLink: HTMLAnchorElement;
     private previousChapterLink: HTMLAnchorElement;
@@ -304,6 +304,7 @@ export default class IFrameNavigator implements Navigator {
                 linkElement.text = link.title || "";
                 linkElement.addEventListener("click", (event: Event) => {
                     event.preventDefault();
+                    event.stopPropagation();
                     this.navigate({
                         resource: linkElement.href,
                         position: 0
@@ -458,6 +459,7 @@ export default class IFrameNavigator implements Navigator {
         this.toggleDisplay(this.links);
         this.toggleDisplay(this.linksBottom);
         event.preventDefault();
+        event.stopPropagation();
     }
 
     private handlePreviousPageClick(event: MouseEvent | TouchEvent): void {
@@ -476,6 +478,7 @@ export default class IFrameNavigator implements Navigator {
                 this.saveCurrentReadingPosition();
             }
             event.preventDefault();
+            event.stopPropagation();
         }
     }
 
@@ -495,6 +498,7 @@ export default class IFrameNavigator implements Navigator {
                 this.saveCurrentReadingPosition();
             }
             event.preventDefault();
+            event.stopPropagation();
         }
     }
 
@@ -589,6 +593,7 @@ export default class IFrameNavigator implements Navigator {
             this.navigate(position);
         }
         event.preventDefault();
+        event.stopPropagation();
     }
 
     private handleNextChapterClick(event: MouseEvent): void {
@@ -600,6 +605,7 @@ export default class IFrameNavigator implements Navigator {
             this.navigate(position);
         }
         event.preventDefault();
+        event.stopPropagation();
     }
 
     private handleStartClick(event: MouseEvent): void {
@@ -611,12 +617,14 @@ export default class IFrameNavigator implements Navigator {
             this.navigate(position);
         }
         event.preventDefault();
+        event.stopPropagation();
     }
 
     private handleContentsClick(event: MouseEvent): void {
         this.hideSettings();
         this.toggleDisplay(this.tocView, this.contentsControl);
         event.preventDefault();
+        event.stopPropagation();
     }
 
     private hideTOC(): void {
@@ -639,6 +647,7 @@ export default class IFrameNavigator implements Navigator {
         this.hideTOC();
         this.toggleDisplay(this.settingsView, this.settingsControl);
         event.preventDefault();
+        event.stopPropagation();
     }
 
     private hideSettings(): void {

--- a/src/ScrollingBookView.ts
+++ b/src/ScrollingBookView.ts
@@ -11,13 +11,16 @@ export default class ScrollingBookView implements BookView {
     private setIFrameSize(): void {
         // Remove previous iframe height so body scroll height will be accurate.
         this.bookElement.style.height = "";
+        this.bookElement.style.width = document.body.offsetWidth + "px";
 
-        this.bookElement.style.width = (document.body.offsetWidth - this.sideMargin * 2) + "px";
-        this.bookElement.style.marginLeft = this.sideMargin + "px";
-        this.bookElement.style.marginRight = this.sideMargin + "px";
+        const body = this.bookElement.contentDocument.body;
+
+        body.style.width = (document.body.offsetWidth - this.sideMargin * 2) + "px";
+        body.style.marginLeft = this.sideMargin + "px";
+        body.style.marginRight = this.sideMargin + "px";
 
         const minHeight = this.height;
-        const bodyHeight = this.bookElement.contentDocument.body.scrollHeight;
+        const bodyHeight = body.scrollHeight;
         this.bookElement.style.height = Math.max(minHeight, bodyHeight) + "px";
     }
 
@@ -28,8 +31,11 @@ export default class ScrollingBookView implements BookView {
     public stop(): void {
         this.bookElement.style.height = "";
         this.bookElement.style.width = "";
-        this.bookElement.style.marginLeft = "";
-        this.bookElement.style.marginRight = "";
+
+        const body = this.bookElement.contentDocument.body;
+        body.style.width = "";
+        body.style.marginLeft = "";
+        body.style.marginRight = "";
     }
 
     public getCurrentPosition(): number {

--- a/src/styles/sass/main.scss
+++ b/src/styles/sass/main.scss
@@ -8,11 +8,11 @@
 //////////////////////////////
 // Global styles           //
 //////////////////////////////
+
 body {
   font-family: $sans-serif-stack;
   font-size: $basefont;
   margin: 0 auto;
-  overflow: hidden;
 }
 
 ul li {
@@ -217,6 +217,18 @@ a {
   }
   &.bottom {
     line-height: 2rem;
+  }
+}
+
+$transparent-nypl-gray: rgba($nypl-gray, 0.1);
+
+iframe {
+  &.left-hover {
+    background: linear-gradient(to right, $transparent-nypl-gray, $transparent-nypl-gray 28%, white 30%, white);
+  }
+
+  &.right-hover {
+    background: linear-gradient(to left, $transparent-nypl-gray, $transparent-nypl-gray 28%, white 30%, white);
   }
 }
 

--- a/test/ColumnsPaginatedBookViewTests.ts
+++ b/test/ColumnsPaginatedBookViewTests.ts
@@ -21,6 +21,12 @@ describe("ColumnsPaginatedBookView", () => {
     });
 
     describe("#start", () => {
+        it("should set up document body to prevent overscroll on ios", () => {
+            paginator.start(0);
+            expect(document.body.style.overflow).to.equal("hidden");
+            expect(document.body.style.position).to.equal("fixed");
+        });
+
         it("should set up columns on the iframe body", () => {
             paginator.start(0);
             const body = iframe.contentDocument.body as any;
@@ -73,11 +79,13 @@ describe("ColumnsPaginatedBookView", () => {
         it("should remove styling from iframe and iframe body", () => {
             paginator.start(0);
 
+            expect(document.body.style.overflow).not.to.equal("scroll");
             expect(iframe.style.height).not.to.equal("");
             expect(iframe.contentDocument.body.style.columnWidth).not.to.equal("");
 
             paginator.stop();
 
+            expect(document.body.style.overflow).to.equal("scroll");
             expect(iframe.style.height).to.equal("");
             expect(iframe.contentDocument.body.style.columnWidth).to.equal("");
         });

--- a/test/EventHandlerTests.ts
+++ b/test/EventHandlerTests.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import { stub } from "sinon";
+import * as jsdom from "jsdom";
 
 import EventHandler from "../src/EventHandler";
 
@@ -390,6 +391,38 @@ describe("EventHandler", () => {
 
                 expect(onForwardSwipe.callCount).to.equal(1);
                 expect(onRightTap.callCount).to.equal(0);
+            });
+        });
+
+        describe("click events", () => {
+            let openStub: Sinon.SinonStub;
+
+            beforeEach(() => {
+                openStub = stub(window, "open");
+
+                eventHandler.setupEvents(element);
+            });
+
+            afterEach(() => {
+                openStub.restore();
+            });
+
+            it("should open external link in a new tab", async () => {
+                event("click", 10, 0, link);
+
+                await pause(250);
+
+                expect(openStub.callCount).to.equal(1);
+                expect(openStub.args[0][0]).to.equal(link.href);
+            });
+
+            it("should do nothing on a single click on an internal link", async () => {
+                jsdom.changeURL(window, "http://example.com");
+                event("click", 10, 0, link);
+
+                await pause(250);
+
+                expect(openStub.callCount).to.equal(0);
             });
         });
     });

--- a/test/EventHandlerTests.ts
+++ b/test/EventHandlerTests.ts
@@ -89,6 +89,8 @@ describe("EventHandler", () => {
         const child = window.document.createElement("span");
         parentLink.appendChild(child);
         element.appendChild(parentLink);
+
+        (window as any).devicePixelRatio = 2;
     });
 
     describe("#setupEvents", () => {

--- a/test/EventHandlerTests.ts
+++ b/test/EventHandlerTests.ts
@@ -1,0 +1,394 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import EventHandler from "../src/EventHandler";
+
+describe("EventHandler", () => {
+    let eventHandler: EventHandler;
+
+    let onLeftTap: Sinon.SinonStub;
+    let onMiddleTap: Sinon.SinonStub;
+    let onRightTap: Sinon.SinonStub;
+    let onBackwardSwipe: Sinon.SinonStub;
+    let onForwardSwipe: Sinon.SinonStub;
+    let onLeftHover: Sinon.SinonStub;
+    let onRightHover: Sinon.SinonStub;
+    let onRemoveHover: Sinon.SinonStub;
+
+    let element: HTMLElement;
+    let div: HTMLDivElement;
+    let span: HTMLSpanElement;
+    let link: HTMLAnchorElement;
+    let parentLink: HTMLAnchorElement;
+
+    let linkClicked: Sinon.SinonStub;
+    let parentLinkClicked: Sinon.SinonStub;
+
+    const event = (type: string, x: number = 0, y: number = 0, target: HTMLElement = div) => {
+        const event = document.createEvent("UIEvent") as any;
+        event.initEvent(type, true, true);
+        if (type.indexOf("touch") !== -1) {
+            event.changedTouches = [{
+                clientX: x,
+                clientY: y
+            }];
+        } else {
+            event.clientX = x;
+            event.clientY = y;
+        }
+        target.dispatchEvent(event);
+    };
+
+    const pause = (ms = 0): Promise<void> => {
+        return new Promise<void>(resolve => setTimeout(resolve, ms));
+    };
+
+    beforeEach(() => {
+        eventHandler = new EventHandler();
+
+        onLeftTap = stub();
+        onMiddleTap = stub();
+        onRightTap = stub();
+        onBackwardSwipe = stub();
+        onForwardSwipe = stub();
+        onLeftHover = stub();
+        onRightHover = stub();
+        onRemoveHover = stub();
+
+        eventHandler.onLeftTap = onLeftTap;
+        eventHandler.onMiddleTap = onMiddleTap;
+        eventHandler.onRightTap = onRightTap;
+        eventHandler.onBackwardSwipe = onBackwardSwipe;
+        eventHandler.onForwardSwipe = onForwardSwipe;
+        eventHandler.onLeftHover = onLeftHover;
+        eventHandler.onRightHover = onRightHover;
+        eventHandler.onRemoveHover = onRemoveHover;
+
+        element = window.document.createElement("div");
+
+        div = window.document.createElement("div");
+        element.appendChild(div);
+
+        span = window.document.createElement("span");
+        link = window.document.createElement("a");
+        link.href = "http://example.com";
+        link.protocol = "http";
+        link.port = "";
+        link.hostname = "example.com";
+        linkClicked = stub();
+        link.addEventListener("click", linkClicked);
+        element.appendChild(link);
+
+        parentLink = window.document.createElement("a");
+        parentLink.href = "http://example.com";
+        parentLink.protocol = "http";
+        parentLink.port = "";
+        parentLink.hostname = "example.com";
+        parentLinkClicked = stub();
+        parentLink.addEventListener("click", parentLinkClicked);
+        const child = window.document.createElement("span");
+        parentLink.appendChild(child);
+        element.appendChild(parentLink);
+    });
+
+    describe("#setupEvents", () => {
+        describe("mouse events", () => {
+            beforeEach(() => {
+                eventHandler.setupEvents(element);
+            });
+
+            it("should do nothing if there's an end event without a start event", async () => {
+                event("mouseup", 10);
+                await pause(250);
+                expect(onLeftTap.callCount).to.equal(0);
+            });
+
+            it("should do nothing on double click", async () => {
+                event("mousedown", 10);
+                event("mouseup", 10);
+
+                await pause(150);
+
+                event("mousedown", 10);
+                event("mouseup", 10);
+
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(0);
+            });
+
+            it("should do nothing on a single click on a link", async () => {
+                event("mousedown", 10, 0, link);
+                event("mouseup", 10, 0, link);
+
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(0);
+            });
+
+            it("should do nothing on a single click on a child of a link", async () => {
+                event("mousedown", 10, 0, span);
+                event("mouseup", 10, 0, span);
+
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(0);
+            });
+
+            it("should handle single click on left", async () => {
+                event("mousedown", 10);
+                event("mouseup", 10);
+
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(1);
+            });
+
+            it("should handle single click in middle", async () => {
+                event("mousedown", 500);
+                event("mouseup", 500);
+
+                await pause(250);
+
+                expect(onMiddleTap.callCount).to.equal(1);
+            });
+
+            it("should handle single click on right", async () => {
+                event("mousedown", 1000);
+                event("mouseup", 1000);
+
+                await pause(250);
+
+                expect(onRightTap.callCount).to.equal(1);
+            });
+
+            it("should do nothing on swipe/highlight", async () => {
+                event("mousedown", 10);
+                event("mouseup", 500);
+
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(0);
+                expect(onMiddleTap.callCount).to.equal(0);
+                expect(onBackwardSwipe.callCount).to.equal(0);
+                expect(onForwardSwipe.callCount).to.equal(0);
+            });
+
+            it("should handle mouseenter on left", () => {
+                event("mouseenter");
+                expect(onLeftHover.callCount).to.equal(1);
+            });
+
+            it("should handle mouseenter on right", () => {
+                event("mouseenter", 800);
+                expect(onRightHover.callCount).to.equal(1);
+            });
+
+            it("should handle mouseenter in middle", () => {
+                event("mouseenter", 500);
+                expect(onLeftHover.callCount).to.equal(0);
+                expect(onRightHover.callCount).to.equal(0);
+                expect(onRemoveHover.callCount).to.equal(1);
+            });
+
+            it("should handle mousemove to left", () => {
+                event("mousemove");
+                expect(onLeftHover.callCount).to.equal(1);
+            });
+
+            it("should handle mousemove to right", () => {
+                event("mousemove", 800);
+                expect(onRightHover.callCount).to.equal(1);
+            });
+
+            it("should handle mousemove to middle", () => {
+                event("mousemove", 500);
+                expect(onLeftHover.callCount).to.equal(0);
+                expect(onRightHover.callCount).to.equal(0);
+                expect(onRemoveHover.callCount).to.equal(1);
+            });
+
+            it("should handle mouseleave", () => {
+                event("mouseleave");
+                expect(onRemoveHover.callCount).to.equal(1);
+            });
+        });
+
+        describe("touch events", () => {
+            beforeEach(() => {
+                // Mock device that supports touch.
+                window.ontouchstart = () => {};
+
+                eventHandler.setupEvents(element);
+            });
+
+            it("should do nothing if there's an end event without a start event", async () => {
+                event("touchend", 10);
+                await pause(250);
+                expect(onLeftTap.callCount).to.equal(0);
+            });
+
+            it("should do nothing on multitouch", async () => {
+                let e = document.createEvent("UIEvent") as any;
+                e.initEvent("touchstart", true, true);
+                e.changedTouches = [{}, {}];
+                div.dispatchEvent(e);
+                
+                event("touchend");
+
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(0);
+
+                event("touchstart");
+                e = document.createEvent("UIEvent") as any;
+                e.initEvent("touchend", true, true);
+                e.changedTouches = [{}, {}];
+                div.dispatchEvent(e);
+                
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(0);
+            });
+
+            it("should do nothing on event with no changed touches", async () => {
+                let e = document.createEvent("UIEvent") as any;
+                e.initEvent("touchstart", true, true);
+                e.changedTouches = [];
+                div.dispatchEvent(e);
+                
+                event("touchend");
+
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(0);
+
+                event("touchstart");
+                e = document.createEvent("UIEvent") as any;
+                e.initEvent("touchend", true, true);
+                e.changedTouches = [];
+                div.dispatchEvent(e);
+                
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(0);
+            });
+
+            it("should do nothing on double tap", async () => {
+                event("touchstart");
+                event("touchend");
+
+                await pause(150);
+
+                event("touchstart");
+                event("touchend");
+
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(0);
+            });
+
+            it("should do nothing on a long press", async () => {
+                event("touchstart");
+                await pause(501);
+                event("touchend");
+
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(0);
+            });
+
+            it("should do nothing on a single tap on a link", async () => {
+                event("touchstart", 10, 0, link);
+                event("touchend", 10, 0, link);
+
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(0);
+            });
+
+            it("should do nothing on a single tap on a child of a link", async () => {
+                event("touchstart", 10, 0, span);
+                event("touchend", 10, 0, span);
+
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(0);
+            });
+
+            it("should handle single tap on left", async () => {
+                event("touchstart", 10);
+                event("touchend", 10);
+
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(1);
+            });
+
+            it("should handle single click in middle", async () => {
+                event("touchstart", 500);
+                event("touchend", 500);
+
+                await pause(250);
+
+                expect(onMiddleTap.callCount).to.equal(1);
+            });
+
+            it("should handle single click on right", async () => {
+                event("touchstart", 1000);
+                event("touchend", 1000);
+
+                await pause(250);
+
+                expect(onRightTap.callCount).to.equal(1);
+            });
+
+            it("should do nothing on vertical swipe", async () => {
+                event("touchstart", 10, 10);
+                event("touchend", 10, 500);
+
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(0);
+                expect(onMiddleTap.callCount).to.equal(0);
+                expect(onBackwardSwipe.callCount).to.equal(0);
+                expect(onForwardSwipe.callCount).to.equal(0);
+            });
+
+            it("should do nothing on slow swipe", async () => {
+                event("touchstart", 10, 10);
+                await pause(501);
+                event("touchend", 500, 10);
+
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(0);
+                expect(onMiddleTap.callCount).to.equal(0);
+                expect(onBackwardSwipe.callCount).to.equal(0);
+                expect(onForwardSwipe.callCount).to.equal(0);
+            });
+
+            it("should handle backward swipe", async () => {
+                event("touchstart", 300, 10);
+                await pause(100);
+                event("touchend", 800, 10);
+
+                await pause(250);
+
+                expect(onBackwardSwipe.callCount).to.equal(1);
+                expect(onLeftTap.callCount).to.equal(0);
+            });
+
+            it("should handle forward swipe", async () => {
+                event("touchstart", 800, 10);
+                await pause(100);
+                event("touchend", 300, 10);
+
+                await pause(250);
+
+                expect(onForwardSwipe.callCount).to.equal(1);
+                expect(onRightTap.callCount).to.equal(0);
+            });
+        });
+    });
+});

--- a/test/IFrameNavigatorTests.ts
+++ b/test/IFrameNavigatorTests.ts
@@ -299,7 +299,6 @@ describe("IFrameNavigator", () => {
             updateBookView();
             expect(chapterTitle.style.display).not.to.equal("none");
             expect(chapterPosition.style.display).not.to.equal("none");
-            expect(document.body.style.overflow).to.equal("hidden");
             expect(chapterPosition.innerHTML).to.equal("Page 4 of 8");
 
             // A scroll event does nothing when the paginator is selected.
@@ -311,7 +310,6 @@ describe("IFrameNavigator", () => {
             updateBookView();
             expect(chapterTitle.style.display).to.equal("none");
             expect(chapterPosition.style.display).to.equal("none");
-            expect(document.body.style.overflow).to.equal("scroll");
 
             // Now a scroll event saves the new reading position.
             await document.body.onscroll(new UIEvent("scroll"));

--- a/test/ScrollingBookViewTests.ts
+++ b/test/ScrollingBookViewTests.ts
@@ -38,9 +38,10 @@ describe("ScrollingBookView", () => {
 
             scroller.start(0);
             expect(iframe.style.height).to.equal("200px");
-            expect(iframe.style.width).to.equal("28px");
-            expect(iframe.style.marginLeft).to.equal("11px");
-            expect(iframe.style.marginRight).to.equal("11px");
+            expect(iframe.style.width).to.equal("50px");
+            expect(iframe.contentDocument.body.style.width).to.equal("28px");
+            expect(iframe.contentDocument.body.style.marginLeft).to.equal("11px");
+            expect(iframe.contentDocument.body.style.marginRight).to.equal("11px");
 
             // If the content doesn't fill the page, the iframe height is
             // based on the window.
@@ -48,9 +49,10 @@ describe("ScrollingBookView", () => {
 
             scroller.start(0);
             expect(iframe.style.height).to.equal("70px");
-            expect(iframe.style.width).to.equal("28px");
-            expect(iframe.style.marginLeft).to.equal("11px");
-            expect(iframe.style.marginRight).to.equal("11px");
+            expect(iframe.style.width).to.equal("50px");
+            expect(iframe.contentDocument.body.style.width).to.equal("28px");
+            expect(iframe.contentDocument.body.style.marginLeft).to.equal("11px");
+            expect(iframe.contentDocument.body.style.marginRight).to.equal("11px");
         });
     });
 
@@ -62,11 +64,13 @@ describe("ScrollingBookView", () => {
 
             expect(iframe.style.height).not.to.equal("");
             expect(iframe.style.width).not.to.equal("");
+            expect(iframe.contentDocument.body.style.width).not.to.equal("");
 
             scroller.stop();
 
             expect(iframe.style.height).to.equal("");
             expect(iframe.style.width).to.equal("");
+            expect(iframe.contentDocument.body.style.width).to.equal("");
         });
     });
 


### PR DESCRIPTION
This fixes #23
This fixes #22 
This fixes #36
And I think this also fixes #10, since I changed the scrolling view so that the iframe takes the full width but its body has margins.
However, it introduces #40 which I will have to fix in another pr.

This branch adds support for swiping to turn the page on devices that support touch. I tried to avoid conflicting with any native browser gesture handling, and it mostly seems to work. On iOS, Safari does have a swipe from the very left or right edge that goes forward or back in the browser, and there doesn't seem to be anything I can do about that.

On desktop, swiping does nothing and you have to tap to turn the page, but I added a class to the iframe when you are hovering over the left or right side, and css to make that side a little darker.

As part of this, I got rid of the elements that were sitting on top of the iframe and capturing clicks, and put all the event handling into the iframe itself.