### PR TITLE
Made back button configurable

### DIFF
--- a/examples/alice/index.html
+++ b/examples/alice/index.html
@@ -13,8 +13,8 @@
   <script src="fetch.js"></script>
   <script src="webpub-viewer.js"></script>
   <script>
-    require(["LocalStorageStore", "ServiceWorkerCacher", "IFrameNavigator", "ColumnsPaginatedBookView", "ScrollingBookView", "LocalAnnotator", "BookSettings"],
-            function (LocalStorageStore, ServiceWorkerCacher, IFrameNavigator, ColumnsPaginatedBookView, ScrollingBookView, LocalAnnotator, BookSettings) {
+    require(["LocalStorageStore", "ServiceWorkerCacher", "IFrameNavigator", "ColumnsPaginatedBookView", "ScrollingBookView", "LocalAnnotator", "BookSettings", "EventHandler"],
+            function (LocalStorageStore, ServiceWorkerCacher, IFrameNavigator, ColumnsPaginatedBookView, ScrollingBookView, LocalAnnotator, BookSettings, EventHandler) {
       var element = document.getElementById("viewer");
       var webpubManifestUrl = new URL("manifest.json", window.location.href);
       var bookCacheUrl = new URL("appcache.html", window.location.href);
@@ -25,10 +25,11 @@
       var paginator = new ColumnsPaginatedBookView.default();
       var scroller = new ScrollingBookView.default();
       var annotator = new LocalAnnotator.default(store);
+      var eventHandler = new EventHandler.default();
       var fontSizes = [ 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32 ];
       var defaultFontSize = 16;
       BookSettings.default.create(store, [paginator, scroller], fontSizes, defaultFontSize).then(function (settings) {
-        IFrameNavigator.default.create(element, webpubManifestUrl, store, cacher, settings, annotator, paginator, scroller);
+        IFrameNavigator.default.create(element, webpubManifestUrl, store, cacher, settings, annotator, paginator, scroller, eventHandler, new URL("http://example.com"), "Back");
       });
     });
   </script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,4 +12,5 @@ export * from "./LocalAnnotator";
 export * from "./PaginatedBookView";
 export * from "./ColumnsPaginatedBookView";
 export * from "./ScrollingBookView";
+export * from "./EventHandler";
 export * from "./IFrameNavigator";

--- a/src/styles/sass/main.scss
+++ b/src/styles/sass/main.scss
@@ -98,7 +98,7 @@ a {
       li:nth-child(1) {
         margin-right: 12rem;
 
-        a[rel="start"],
+        a[rel="up"],
         .icon,
         span, {
           //display: none;
@@ -112,7 +112,7 @@ a {
           margin: 0.175rem 0 0 0.625rem;
           padding: 0.5rem 0.35rem 0.3rem;
 
-          a[rel="start"] {
+          a[rel="up"] {
             display: inline-block;
           }
 

--- a/test/IFrameNavigatorTests.ts
+++ b/test/IFrameNavigatorTests.ts
@@ -457,14 +457,17 @@ describe("IFrameNavigator", () => {
             });
         });
 
-        it("should navigate to the first spine item", async () => {
-            const iframe = element.querySelector("iframe") as HTMLIFrameElement;
-            iframe.src = "http://example.com/some-other-page.html";
+        it("should show the up link", async () => {
+            const noUpLink = element.querySelector("a[rel=up]");
+            // The up link isn't shown if it's not configured.
+            expect(noUpLink).not.to.be.ok;
 
-            const startLink = element.querySelector("a[rel=start]") as HTMLAnchorElement;
-            expect(startLink.href).to.equal("http://example.com/start.html");
-            click(startLink);
-            expect(iframe.src).to.equal("http://example.com/start.html");
+            navigator = await IFrameNavigator.create(element, new URL("http://example.com/manifest.json"), store, cacher, settings, annotator, paginator, scroller, eventHandler, new URL("http://up.com"), "Up Text");
+            
+            const upLink = element.querySelector("a[rel=up]") as HTMLAnchorElement;
+            expect(upLink).to.be.ok;
+            expect(upLink.href).to.equal("http://up.com/");
+            expect(upLink.innerHTML).to.contain("Up Text");
         });
 
         it("should navigate to the previous spine item", async () => {


### PR DESCRIPTION
This fixes #42

This adds arguments to IFrameNavigator to control the href and text of the up/back link.

By default, it won't show up, and you can pass in the arguments if you want it to be there.

We'll need to modify https://github.com/NYPL-Simplified/web-reader-landing-page/blob/master/book_index.html.template to use this, once we know what it should say and where it should go.

I don't like these arguments but I don't have a better idea right now.