### PR TITLE
Changed LocalStorageStore to use any prefix instead of requiring a manifest URL.

### DIFF
--- a/examples/alice/index.html
+++ b/examples/alice/index.html
@@ -19,7 +19,7 @@
       var webpubManifestUrl = new URL("manifest.json", window.location.href);
       var bookCacheUrl = new URL("appcache.html", window.location.href);
 
-      var store = new LocalStorageStore.default(webpubManifestUrl);
+      var store = new LocalStorageStore.default(webpubManifestUrl.href);
       var cacher = new ServiceWorkerCacher.default(store, webpubManifestUrl, "sw.js", bookCacheUrl);
 
       var paginator = new ColumnsPaginatedBookView.default();

--- a/examples/twenty/index.html
+++ b/examples/twenty/index.html
@@ -21,7 +21,7 @@
       var webpubManifestUrl = new URL("manifest.json", window.location.href);
       var bookCacheUrl = new URL("appcache.html", window.location.href);
 
-      var store = new LocalStorageStore.default(webpubManifestUrl);
+      var store = new LocalStorageStore.default(webpubManifestUrl.href);
       var cacher = new ServiceWorkerCacher.default(store, webpubManifestUrl, "../../sw.js", bookCacheUrl);
 
       var paginator = new ColumnsPaginatedBookView.default();

--- a/src/LocalStorageStore.ts
+++ b/src/LocalStorageStore.ts
@@ -5,15 +5,15 @@ import MemoryStore from "./MemoryStore";
     but falls back to an in-memory store. */
 export default class LocalStorageStore implements Store {
     private fallbackStore: MemoryStore | null;
-    private manifestUrl: URL;
+    private prefix: string;
     
-    public constructor(manifestUrl: URL) {
-        this.manifestUrl = manifestUrl;
+    public constructor(prefix: string) {
+        this.prefix = prefix;
         try {
             // In some browsers (eg iOS Safari in private mode), 
             // localStorage exists but throws an exception when
             // you try to write to it.
-            const testKey = "test-" + String(Math.random());
+            const testKey = prefix + "-" + String(Math.random());
             window.localStorage.setItem(testKey, "test");
             window.localStorage.removeItem(testKey);
             this.fallbackStore = null;
@@ -23,7 +23,7 @@ export default class LocalStorageStore implements Store {
     }
 
     private getLocalStorageKey(key: string): string {
-        return this.manifestUrl.href + "-" + key;
+        return this.prefix + "-" + key;
     }
 
     public async get(key: string): Promise<string | null> {

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,14 +7,15 @@ import BookSettings from "./BookSettings";
 import LocalAnnotator from "./LocalAnnotator";
 
 const app = async (element: HTMLElement, manifestUrl: URL): Promise<IFrameNavigator> => {
-    const store = new LocalStorageStore(manifestUrl);
-    const cacher = new ServiceWorkerCacher(store, manifestUrl);
-    const annotator = new LocalAnnotator(store);
+    const bookStore = new LocalStorageStore(manifestUrl.href);
+    const cacher = new ServiceWorkerCacher(bookStore, manifestUrl);
+    const annotator = new LocalAnnotator(bookStore);
     const paginator = new ColumnsPaginatedBookView();
     const scroller = new ScrollingBookView();
+    const settingsStore = new LocalStorageStore("all-books");
     const fontSizes = [ 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32 ];
-    const settings = await BookSettings.create(store, [paginator, scroller], fontSizes, 16);
-    return await IFrameNavigator.create(element, manifestUrl, store, cacher, settings, annotator, paginator, scroller);
+    const settings = await BookSettings.create(settingsStore, [paginator, scroller], fontSizes, 16);
+    return await IFrameNavigator.create(element, manifestUrl, bookStore, cacher, settings, annotator, paginator, scroller);
 };
 
 export default app;

--- a/test/LocalStorageStoreTests.ts
+++ b/test/LocalStorageStoreTests.ts
@@ -22,7 +22,7 @@ describe("LocalStorageStore", () => {
     });
 
     it("falls back to memory store if localStorage is not available", async () => {
-        store = new LocalStorageStore(new URL("http://example.com/manifest.json"));
+        store = new LocalStorageStore("prefix");
 
         // #get returns null for a value that has not been set.
         let value = await store.get("key");
@@ -36,7 +36,7 @@ describe("LocalStorageStore", () => {
     it("uses localStorage if available, and adds manifest url to keys", async () => {
         mockLocalStorageAPI();
 
-        store = new LocalStorageStore(new URL("http://example.com/manifest.json"));
+        store = new LocalStorageStore("prefix");
 
         getItem.returns(null);
 
@@ -47,18 +47,18 @@ describe("LocalStorageStore", () => {
         // #get returns null for a value that has not been set.
         let value = await store.get("key");
         expect(getItem.callCount).to.equal(1);
-        expect(getItem.args[0][0]).to.equal("http://example.com/manifest.json-key");
+        expect(getItem.args[0][0]).to.equal("prefix-key");
         expect(value).to.equal(null);
 
         await store.set("key", "value");
         expect(setItem.callCount).to.equal(2);
-        expect(setItem.args[1][0]).to.equal("http://example.com/manifest.json-key");
+        expect(setItem.args[1][0]).to.equal("prefix-key");
         expect(setItem.args[1][1]).to.equal("value");
 
         getItem.returns("value");
         value = await store.get("key");
         expect(value).to.equal("value");
         expect(getItem.callCount).to.equal(2);
-        expect(getItem.args[1][0]).to.equal("http://example.com/manifest.json-key");
+        expect(getItem.args[1][0]).to.equal("prefix-key");
     });
 });


### PR DESCRIPTION
I plan to use this to fix #50.

I'll be able to create one LocalStorageStore for settings that uses the same prefix across all books, and another LocalStorageStore for book-specific caching using the manifest URL.