### PR TITLE
Offline improvements

### DIFF
--- a/examples/twenty/index.html
+++ b/examples/twenty/index.html
@@ -22,7 +22,7 @@
       var bookCacheUrl = new URL("appcache.html", window.location.href);
 
       var store = new LocalStorageStore.default(webpubManifestUrl.href);
-      var cacher = new ServiceWorkerCacher.default(store, webpubManifestUrl, "../../sw.js", bookCacheUrl);
+      var cacher = new ServiceWorkerCacher.default(store, webpubManifestUrl, "../sw.js", bookCacheUrl);
 
       var paginator = new ColumnsPaginatedBookView.default();
       var scroller = new ScrollingBookView.default();

--- a/src/ApplicationCacheCacher.ts
+++ b/src/ApplicationCacheCacher.ts
@@ -19,6 +19,7 @@ export default class ApplicationCacheCacher implements Cacher {
     private readonly bookCacheUrl: URL;
     protected bookCacheElement: HTMLIFrameElement;
     private statusUpdateCallback: (status: CacheStatus) => void = () => {};
+    private status: CacheStatus = CacheStatus.Uncached;
 
     public constructor(bookCacheUrl: URL) {
         this.bookCacheUrl = bookCacheUrl;
@@ -56,6 +57,10 @@ export default class ApplicationCacheCacher implements Cacher {
         this.updateStatus();
     }
 
+    public getStatus(): CacheStatus {
+        return this.status;
+    }
+
     protected updateStatus() {
         let status: CacheStatus;
         let appCacheStatus = window.applicationCache.UNCACHED;
@@ -81,10 +86,12 @@ export default class ApplicationCacheCacher implements Cacher {
             status = CacheStatus.Downloaded;
         }
 
+        this.status = status;
         this.statusUpdateCallback(status);
     }
 
     protected handleError() {
+        this.status = CacheStatus.Error;
         this.statusUpdateCallback(CacheStatus.Error);
     }
 }

--- a/src/ApplicationCacheCacher.ts
+++ b/src/ApplicationCacheCacher.ts
@@ -32,16 +32,20 @@ export default class ApplicationCacheCacher implements Cacher {
         this.updateStatus();
 
         this.bookCacheElement.addEventListener("load", () => {
-            this.updateStatus();
+            try {
+                this.updateStatus();
 
-            const bookCache = this.bookCacheElement.contentWindow.applicationCache;
+                const bookCache = this.bookCacheElement.contentWindow.applicationCache;
 
-            bookCache.oncached = this.updateStatus.bind(this);
-            bookCache.onchecking = this.updateStatus.bind(this);
-            bookCache.ondownloading = this.updateStatus.bind(this);
-            bookCache.onerror = this.handleError.bind(this);
-            bookCache.onnoupdate = this.updateStatus.bind(this);
-            bookCache.onupdateready = this.updateStatus.bind(this);
+                bookCache.oncached = this.updateStatus.bind(this);
+                bookCache.onchecking = this.updateStatus.bind(this);
+                bookCache.ondownloading = this.updateStatus.bind(this);
+                bookCache.onerror = this.handleError.bind(this);
+                bookCache.onnoupdate = this.updateStatus.bind(this);
+                bookCache.onupdateready = this.updateStatus.bind(this);
+            } catch (err) {
+                this.handleError();
+            }
         });
 
         return new Promise<void>(resolve => resolve());

--- a/src/Cacher.ts
+++ b/src/Cacher.ts
@@ -25,6 +25,9 @@ interface Cacher {
 
     // Register a function to call when the cache status changes.
     onStatusUpdate(callback: (status: CacheStatus) => void): void;
+
+    // Return the current CacheStatus.
+    getStatus(): CacheStatus;
 }
 
 export default Cacher;

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -349,7 +349,7 @@ export default class IFrameNavigator implements Navigator {
                         href = new URL(link.href, this.manifestUrl.href).href;
                     }
                     linkElement.href = href;
-                    linkElement.text = link.title || "";
+                    linkElement.innerHTML = link.title || "";
                     linkElement.addEventListener("click", (event: Event) => {
                         event.preventDefault();
                         event.stopPropagation();

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -8,7 +8,6 @@ import Annotator from "./Annotator";
 import Manifest from "./Manifest";
 import { Link } from "./Manifest";
 import BookSettings from "./BookSettings";
-import { OfflineStatus } from "./BookSettings";
 import EventHandler from "./EventHandler";
 import * as HTMLUtilities from "./HTMLUtilities";
 
@@ -79,6 +78,10 @@ const template = `
   </nav>
   <main style="overflow: hidden">
     <div class="loading" style="display:none;">Loading</div>
+    <div class="error" style="display:none;">
+      Error
+      <button class="try-again">Try again</button>
+    </div>
     <div class="info top">
       <span class="book-title"></span>
     </div>
@@ -117,6 +120,8 @@ export default class IFrameNavigator implements Navigator {
     private tocView: HTMLDivElement;
     private settingsView: HTMLDivElement;
     private loadingMessage: HTMLDivElement;
+    private errorMessage: HTMLDivElement;
+    private tryAgainButton: HTMLButtonElement;
     private infoTop: HTMLDivElement;
     private infoBottom: HTMLDivElement;
     private bookTitle: HTMLSpanElement;
@@ -158,6 +163,8 @@ export default class IFrameNavigator implements Navigator {
             this.tocView = HTMLUtilities.findRequiredElement(element, "div[class='contents-view controls-view']") as HTMLDivElement;
             this.settingsView = HTMLUtilities.findRequiredElement(element, "div[class='settings-view controls-view']") as HTMLDivElement;
             this.loadingMessage = HTMLUtilities.findRequiredElement(element, "div[class=loading]") as HTMLDivElement;
+            this.errorMessage = HTMLUtilities.findRequiredElement(element, "div[class=error]") as HTMLDivElement;
+            this.tryAgainButton = HTMLUtilities.findRequiredElement(element, "button[class=try-again]") as HTMLButtonElement;
             this.infoTop = HTMLUtilities.findRequiredElement(element, "div[class='info top']") as HTMLDivElement;
             this.infoBottom = HTMLUtilities.findRequiredElement(element, "div[class='info bottom']") as HTMLDivElement;
             this.bookTitle = HTMLUtilities.findRequiredElement(this.infoTop, "span[class=book-title]") as HTMLSpanElement;
@@ -178,11 +185,8 @@ export default class IFrameNavigator implements Navigator {
             this.settings.renderControls(this.settingsView);
             this.settings.onViewChange(this.updateBookView.bind(this));
             this.settings.onFontSizeChange(this.updateFontSize.bind(this));
-            this.settings.onOfflineEnabled(this.enableOffline.bind(this));
             this.cacher.onStatusUpdate(this.updateOfflineCacheStatus.bind(this));
-            if (this.settings.getOfflineStatus() === OfflineStatus.Enabled) {
-                this.enableOffline();
-            }
+            this.enableOffline();
 
             return await this.loadManifest();
         } catch (err) {
@@ -208,6 +212,8 @@ export default class IFrameNavigator implements Navigator {
         this.settingsControl.addEventListener("click", this.handleSettingsClick.bind(this));
 
         this.settingsView.addEventListener("click", this.hideSettings.bind(this));
+
+        this.tryAgainButton.addEventListener("click", this.tryAgain.bind(this));
     }
 
     private updateBookView(): void {
@@ -250,7 +256,9 @@ export default class IFrameNavigator implements Navigator {
     }
 
     private enableOffline(): void {
-        this.cacher.enable();
+        if (this.cacher.getStatus() !== CacheStatus.Downloaded) {
+            this.cacher.enable();
+        }
     }
 
     private updateOfflineCacheStatus(status: CacheStatus): void {
@@ -343,97 +351,103 @@ export default class IFrameNavigator implements Navigator {
     }
 
     private async handleIFrameLoad(): Promise<void> {
+        this.errorMessage.style.display = "none";
         this.showLoadingMessageAfterDelay();
-        if (!this.firstLoad) {
-            this.hideTOC();
-        }
-        this.firstLoad = false;
-
-        let bookViewPosition = 0;
-        if (this.newPosition) {
-            bookViewPosition = this.newPosition.position;
-            this.newPosition = null;
-        }
-        this.updateBookView();
-        this.updateFontSize();
-        this.settings.getSelectedView().start(bookViewPosition);
-
-        if (this.newElementId) {
-            this.settings.getSelectedView().goToElement(this.newElementId);
-            this.newElementId = null;
-        }
-
-        let currentLocation = this.iframe.src;
-        if (this.iframe.contentDocument && this.iframe.contentDocument.location && this.iframe.contentDocument.location.href) {
-            currentLocation = this.iframe.contentDocument.location.href;
-        }
-
-        if (currentLocation.indexOf("#") !== -1) {
-            // Letting the iframe load the anchor itself doesn't always work.
-            // For example, with CSS column-based pagination, you can end up
-            // between two columns, and we can't reset the position in some
-            // browsers. Instead, we grab the element id and reload the iframe
-            // without it, then let the view figure out how to go to that element
-            // on the next load event.
-
-            const elementId = currentLocation.slice(currentLocation.indexOf("#") + 1);
-            // Set the element to go to the next time the iframe loads.
-            this.newElementId = elementId;
-            // Reload the iframe without the anchor.
-            this.iframe.src = currentLocation.slice(0, currentLocation.indexOf("#"));
-            return new Promise<void>(resolve => resolve());
-        }
-
-        this.updatePositionInfo();
-
-        const manifest = await Manifest.getManifest(this.manifestUrl, this.store);
-        const previous = manifest.getPreviousSpineItem(currentLocation);
-        if (previous && previous.href) {
-            this.previousChapterLink.href = new URL(previous.href, this.manifestUrl.href).href;
-            this.previousChapterLink.className = "";
-        } else {
-            this.previousChapterLink.removeAttribute("href");
-            this.previousChapterLink.className = "disabled";
-        }
-
-        const next = manifest.getNextSpineItem(currentLocation);
-        if (next && next.href) {
-            this.nextChapterLink.href = new URL(next.href, this.manifestUrl.href).href;
-            this.nextChapterLink.className = "";
-        } else {
-            this.nextChapterLink.removeAttribute("href");
-            this.nextChapterLink.className = "disabled";
-        }
-
-        this.setActiveTOCItem(currentLocation);
-
-        if (manifest.metadata.title) {
-            this.bookTitle.innerHTML = manifest.metadata.title;
-        }
-
-        const spineItem = manifest.getSpineItem(currentLocation);
-        if (spineItem !== null) {
-            if (spineItem.title) {
-                this.chapterTitle.innerHTML = "(" + spineItem.title + ")";
-            } else {
-                this.chapterTitle.innerHTML = "(Chapter)";
+        try {
+            if (!this.firstLoad) {
+                this.hideTOC();
             }
-        }
+            this.firstLoad = false;
 
-        if (this.eventHandler) {
-            this.eventHandler.setupEvents(this.iframe.contentDocument);
-        }
+            let bookViewPosition = 0;
+            if (this.newPosition) {
+                bookViewPosition = this.newPosition.position;
+                this.newPosition = null;
+            }
+            this.updateBookView();
+            this.updateFontSize();
+            this.settings.getSelectedView().start(bookViewPosition);
 
-        if (this.annotator) {
-            await this.saveCurrentReadingPosition();
-        }
-        this.hideLoadingMessage();
+            if (this.newElementId) {
+                this.settings.getSelectedView().goToElement(this.newElementId);
+                this.newElementId = null;
+            }
 
-        if (this.settings.getOfflineStatus() === OfflineStatus.NoSelection) {
-            setTimeout(this.settings.askUserToEnableOfflineUse.bind(this.settings), 0);
-        }
+            let currentLocation = this.iframe.src;
+            if (this.iframe.contentDocument && this.iframe.contentDocument.location && this.iframe.contentDocument.location.href) {
+                currentLocation = this.iframe.contentDocument.location.href;
+            }
 
-        return new Promise<void>(resolve => resolve());
+            if (currentLocation.indexOf("#") !== -1) {
+                // Letting the iframe load the anchor itself doesn't always work.
+                // For example, with CSS column-based pagination, you can end up
+                // between two columns, and we can't reset the position in some
+                // browsers. Instead, we grab the element id and reload the iframe
+                // without it, then let the view figure out how to go to that element
+                // on the next load event.
+
+                const elementId = currentLocation.slice(currentLocation.indexOf("#") + 1);
+                // Set the element to go to the next time the iframe loads.
+                this.newElementId = elementId;
+                // Reload the iframe without the anchor.
+                this.iframe.src = currentLocation.slice(0, currentLocation.indexOf("#"));
+                return new Promise<void>(resolve => resolve());
+            }
+
+            this.updatePositionInfo();
+
+            const manifest = await Manifest.getManifest(this.manifestUrl, this.store);
+            const previous = manifest.getPreviousSpineItem(currentLocation);
+            if (previous && previous.href) {
+                this.previousChapterLink.href = new URL(previous.href, this.manifestUrl.href).href;
+                this.previousChapterLink.className = "";
+            } else {
+                this.previousChapterLink.removeAttribute("href");
+                this.previousChapterLink.className = "disabled";
+            }
+
+            const next = manifest.getNextSpineItem(currentLocation);
+            if (next && next.href) {
+                this.nextChapterLink.href = new URL(next.href, this.manifestUrl.href).href;
+                this.nextChapterLink.className = "";
+            } else {
+                this.nextChapterLink.removeAttribute("href");
+                this.nextChapterLink.className = "disabled";
+            }
+
+            this.setActiveTOCItem(currentLocation);
+
+            if (manifest.metadata.title) {
+                this.bookTitle.innerHTML = manifest.metadata.title;
+            }
+
+            const spineItem = manifest.getSpineItem(currentLocation);
+            if (spineItem !== null) {
+                if (spineItem.title) {
+                    this.chapterTitle.innerHTML = "(" + spineItem.title + ")";
+                } else {
+                    this.chapterTitle.innerHTML = "(Chapter)";
+                }
+            }
+
+            if (this.eventHandler) {
+                this.eventHandler.setupEvents(this.iframe.contentDocument);
+            }
+
+            if (this.annotator) {
+                await this.saveCurrentReadingPosition();
+            }
+            this.hideLoadingMessage();
+            return new Promise<void>(resolve => resolve());
+        } catch (err) {
+            this.errorMessage.style.display = "block";
+            return new Promise<void>((_, reject) => reject());
+        }
+    }
+
+    private tryAgain() {
+        this.iframe.src = this.iframe.src;
+        this.enableOffline();
     }
 
     private toggleDisplay(element: HTMLDivElement | HTMLUListElement, control?: HTMLAnchorElement | HTMLButtonElement): void {

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -78,7 +78,7 @@ const template = `
   <main style="overflow: hidden">
     <div class="loading" style="display:none;">Loading</div>
     <div class="error" style="display:none;">
-      Error
+      <span>Error</span>
       <button class="try-again">Try again</button>
     </div>
     <div class="info top">

--- a/src/styles/sass/_colors.scss
+++ b/src/styles/sass/_colors.scss
@@ -22,7 +22,7 @@ $mta-white: #fff;
 $mta-black: #111;
 
 // NYPL Reds
-$nypl-red: #d0343a;
+$mta-error-red: #d0343a;
 
 $nypl-red-dark: #97272c;
 

--- a/src/styles/sass/main.scss
+++ b/src/styles/sass/main.scss
@@ -187,6 +187,21 @@ a {
   width: 12.5rem;
 }
 
+.error {
+  background-color: darken($nypl-white, 2.5%);
+  border: 1px solid $nypl-red;
+  border-radius: 0.3125rem;
+  color: $nypl-red;
+  font-family: $sans-serif-stack;
+  height: 2.5rem;
+  left: calc(50% - 6.25rem);
+  padding-top: 1.25rem;
+  position: fixed;
+  text-align: center;
+  top: calc(50% - 6.25rem);
+  width: 12.5rem;
+}
+
 .controls-view {
   font-family: $sans-serif-stack;
   font-size: $basefont;

--- a/src/styles/sass/main.scss
+++ b/src/styles/sass/main.scss
@@ -265,18 +265,32 @@ a {
 }
 
 .error {
-  background-color: darken($nypl-white, 2.5%);
-  border: 1px solid $nypl-red;
-  border-radius: 0.3125rem;
-  color: $nypl-red;
-  font-family: $sans-serif-stack;
-  height: 2.5rem;
-  left: calc(50% - 6.25rem);
-  padding-top: 1.25rem;
+  background-color: transparentize($mta-white, 0.125);
+  //border: 2px solid $mta-error-red;
+  color: $mta-error-red;
+  //font-family: $sans-serif-stack;
+  height: 100%;
+  //left: calc(50% - 6.25rem);
+  padding-top: 40vh;
   position: fixed;
   text-align: center;
-  top: calc(50% - 6.25rem);
-  width: 12.5rem;
+  //top: calc(50% - 6.25rem);
+  width: 100%;
+
+  span {
+    display: block;
+    margin-bottom: 0.75rem;
+  }
+
+  button {
+    color: $mta-error-red;
+    border: 0.125rem solid $mta-error-red;
+    border-radius: 0.3125rem;
+    //box-shadow: 0 0 17rem 3.75rem transparentize($mta-dark-gray, 0.9);
+    font-size: 1rem;
+    font-weight: 700;
+    padding: 1.4rem;
+  }
 }
 
 .controls-view {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -21,8 +21,16 @@ self.addEventListener('activate', () => {
 });
 
 self.addEventListener('fetch', event => {
-    const cachedOrFetchedResponse = self.caches.match((event as any).request).then(response => {
-        return response || self.fetch((event as any).request);
+    const cachedResponse = self.caches.match((event as any).request).then(response => {
+        return response || Promise.reject("not cached");
     });
-    (event as any).respondWith(cachedOrFetchedResponse);
+
+    const update = self.caches.open(CACHE_NAME).then((cache: any) => {
+        return self.fetch((event as any).request).then((response: any) => {
+            return cache.put((event as any).request, response);
+        });
+    });
+
+    (event as any).respondWith(cachedResponse);
+    (event as any).waitUntil(update);
 });

--- a/test/BookSettingsTest.ts
+++ b/test/BookSettingsTest.ts
@@ -2,7 +2,6 @@ import { expect } from "chai";
 import { stub } from "sinon";
 
 import BookSettings from "../src/BookSettings";
-import { OfflineStatus } from "../src/BookSettings";
 import BookView from "../src/BookView";
 import MemoryStore from "../src/MemoryStore";
 
@@ -108,20 +107,6 @@ describe("BookSettings", () => {
 
             settings = await BookSettings.create(store, [view1, view2], [10, 12, 14, 16]);
             expect(settings.getSelectedFontSize()).to.equal("14px");
-        });
-
-        it("obtains the selected offline setting from the store", async () => {
-            await store.set("settings-offline-enabled", "true");
-            settings = await BookSettings.create(store, [view1], [12]);
-            expect(settings.getOfflineStatus()).to.equal(OfflineStatus.Enabled);
-
-            await store.set("settings-offline-enabled", "false");
-            settings = await BookSettings.create(store, [view1], [12]);
-            expect(settings.getOfflineStatus()).to.equal(OfflineStatus.Disabled);
-        });
-
-        it("has no offline selection if there isn't one in the store", async () => {
-            expect(settings.getOfflineStatus()).to.equal(OfflineStatus.NoSelection);
         });
     });
 
@@ -274,32 +259,11 @@ describe("BookSettings", () => {
             expect(storedFontSize).to.equal("16px");
         });
 
-        it("renders offline button and status", async () => {
+        it("renders offline status", async () => {
             const element = document.createElement("div");
             settings.renderControls(element);
 
-            let offlineButton = element.querySelector("button[class='enable-offline']") as HTMLButtonElement;
-            expect(offlineButton.innerHTML).to.contain("offline");
-            expect(offlineButton.style.display).not.to.equal("none");
-
-            let offlineStatus = element.querySelector("div[class='offline-status']") as HTMLDivElement;
-            expect(offlineStatus).not.to.be.null;
-
-            click(offlineButton);
-            await pause();
-            expect(settings.getOfflineStatus()).to.equal(OfflineStatus.Enabled);
-
-            const storedOfflineEnabled = await store.get("settings-offline-enabled");
-            expect(storedOfflineEnabled).to.equal("true");
-
-            store.set("settings-offline-enabled", "true");
-            settings = await BookSettings.create(store, [view1], [12]);
-            settings.renderControls(element);
-
-            offlineButton = element.querySelector("button[class='enable-offline']") as HTMLButtonElement;
-            expect(offlineButton.style.display).to.equal("none");
-
-            offlineStatus = element.querySelector("div[class='offline-status']") as HTMLDivElement;
+            const offlineStatus = element.querySelector("div[class='offline-status']") as HTMLDivElement;
             expect(offlineStatus).not.to.be.null;
         });
 
@@ -363,48 +327,6 @@ describe("BookSettings", () => {
             click(increaseButton);
             await pause();
             expect(fontSizeChanged.callCount).to.equal(2);
-        });
-    });
-
-    describe("#onOfflineEnabled", () => {
-        it("sets up offline enabled callback", async () => {
-            const element = document.createElement("div");
-            settings.renderControls(element);
-
-            const offlineEnabled = stub();
-            settings.onOfflineEnabled(offlineEnabled);
-
-            const offlineButton = element.querySelector("button[class='enable-offline']") as HTMLButtonElement;
-            click(offlineButton);
-            await pause();
-            expect(offlineEnabled.callCount).to.equal(1);
-        });
-    });
-
-    describe("#askUserToEnableOfflineUse", () => {
-        it("sets offline status based on user's response", async () => {
-            const offlineEnabled = stub();
-            settings.onOfflineEnabled(offlineEnabled);
-
-            const element = document.createElement("div");
-            settings.renderControls(element);
-
-            const confirmStub = stub(window, "confirm").returns(true);
-            await settings.askUserToEnableOfflineUse();
-            expect(settings.getOfflineStatus()).to.equal(OfflineStatus.Enabled);
-            let storedSetting = await store.get("settings-offline-enabled");
-            expect(storedSetting).to.equal("true");
-            let offlineButton = element.querySelector("button[class='enable-offline']") as HTMLButtonElement;
-            expect(offlineButton.style.display).to.equal("none");
-            expect(offlineEnabled.callCount).to.equal(1);
-
-            confirmStub.returns(false);
-            await settings.askUserToEnableOfflineUse();
-            expect(settings.getOfflineStatus()).to.equal(OfflineStatus.Disabled);
-            storedSetting = await store.get("settings-offline-enabled");
-            expect(storedSetting).to.equal("false");
-            expect(offlineButton.style.display).not.to.equal("none");
-            expect(offlineEnabled.callCount).to.equal(1);
         });
     });
 });


### PR DESCRIPTION
This fixes #18 
This fixes #32 
This fixes #45 

I removed the initial popup asking if you'd like to download for offline use. Now it will always attempt to download.

I improved the error handling when attempting to load something in the iframe that's not cached. If there's an exception during iframe load, it will show an error popup with a button to try again. The button will reload the iframe and also attempt to restart the caching.