### PR TITLE
Scrolling suggestion for screen readers/keyboard nav and tab index fixes

### DIFF
--- a/src/BookSettings.ts
+++ b/src/BookSettings.ts
@@ -14,8 +14,8 @@ const sectionTemplate = (options: string) => `
     </ul></li>
 `;
 
-const optionTemplate = (liClassName: string, buttonClassName: string, label: string, role: string, svgCheckIcon: string, buttonId: string) => `
-    <li class='${liClassName}'><button id='${buttonId}' class='${buttonClassName}' role='${role}'>${label}${svgCheckIcon}</button></li>
+const optionTemplate = (liClassName: string, buttonClassName: string, label: string, role: string, svgIcon: string, buttonId: string) => `
+    <li class='${liClassName}'><button id='${buttonId}' class='${buttonClassName}' role='${role}'>${label}${svgIcon}</button></li>
 `;
 
 const offlineTemplate = `
@@ -210,8 +210,10 @@ export default class BookSettings {
         for (const view of this.bookViews) {
             if (view === this.selectedView) {
                 this.viewButtons[view.name].className = view.name + " active";
+                this.viewButtons[view.name].setAttribute("aria-label", view.label + " mode enabled");
             } else {
                 this.viewButtons[view.name].className = view.name;
+                this.viewButtons[view.name].setAttribute("aria-label", view.label + " mode disabled");
             }
         }
     }

--- a/src/BookSettings.ts
+++ b/src/BookSettings.ts
@@ -15,7 +15,7 @@ const sectionTemplate = (options: string) => `
 `;
 
 const optionTemplate = (liClassName: string, buttonClassName: string, label: string, role: string) => `
-    <li class='${liClassName}'><button class='${buttonClassName}' role='${role}'>${label}</button></li>
+    <li class='${liClassName}'><button class='${buttonClassName}' role='${role}' tabindex=-1>${label}</button></li>
 `;
 
 const offlineTemplate = `

--- a/src/BookSettings.ts
+++ b/src/BookSettings.ts
@@ -14,8 +14,8 @@ const sectionTemplate = (options: string) => `
     </ul></li>
 `;
 
-const optionTemplate = (liClassName: string, buttonClassName: string, label: string, role: string) => `
-    <li class='${liClassName}'><button class='${buttonClassName}' role='${role}'>${label}</button></li>
+const optionTemplate = (liClassName: string, buttonClassName: string, label: string, role: string, svgCheckIcon: string, buttonId: string) => `
+    <li class='${liClassName}'><button id='${buttonId}' class='${buttonClassName}' role='${role}'>${label}${svgCheckIcon}</button></li>
 `;
 
 const offlineTemplate = `
@@ -33,6 +33,12 @@ const decreaseSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="60" height="
 const increaseSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="60" height="60" viewBox="0 0 60 60" preserveAspectRatio="xMidYMid meet" role="img" aria-labelledby="increase-font-size" class="icon">
   <title id="increase-font-size">Increase Font Size</title>
     <path d="M30,0A30,30,0,1,0,60,30,30,30,0,0,0,30,0ZM47.41144,32h-15.5V47.49841h-4V32h-15.5V28h15.5V12.49841h4V28h15.5Z"/>
+</svg>
+`;
+
+const checkSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 45 32" preserveAspectRatio="xMidYMid meet" class="checkedIcon" aria-label="check-icon" role="img">
+  <title id="check-icon">check icon</title>
+  <path d="M18.05257,31.0625,2.00775,15.01814a1,1,0,0,1,0-1.41422l2.535-2.535a1,1,0,0,1,1.4142,0L18.05257,23.16406,40.57154.646a1,1,0,0,1,1.4142,0l2.535,2.535a1,1,0,0,1,0,1.41423Z" />
 </svg>
 `;
 
@@ -109,14 +115,14 @@ export default class BookSettings {
 
         if (this.bookViews.length > 1) {
             const viewOptions = this.bookViews.map(bookView =>
-                optionTemplate("reading-style", bookView.name, bookView.label, "menuitem")
+                optionTemplate("reading-style", bookView.name, bookView.label, "menuitem", checkSvg, bookView.label)
             );
             sections.push(sectionTemplate(viewOptions.join("")));
         }
 
         if (this.fontSizes.length > 1) {
             const fontSizeLabel = "<li class='font-size-label'>A</li>";
-            const fontSizeOptions = optionTemplate("font-setting", "decrease", decreaseSvg, "menuitem") + fontSizeLabel + optionTemplate("font-setting", "increase", increaseSvg, "menuitem");
+            const fontSizeOptions = optionTemplate("font-setting", "decrease", decreaseSvg, "menuitem", "", "") + fontSizeLabel + optionTemplate("font-setting", "increase", increaseSvg, "menuitem", "", "");
             sections.push(sectionTemplate(fontSizeOptions));
         }
         sections.push(offlineTemplate);

--- a/src/BookSettings.ts
+++ b/src/BookSettings.ts
@@ -37,7 +37,7 @@ const increaseSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="60" height="
 `;
 
 const checkSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 45 32" preserveAspectRatio="xMidYMid meet" class="checkedIcon" aria-label="check-icon" role="img">
-  <title id="check-icon">check icon</title>
+  <title>check icon</title>
   <path d="M18.05257,31.0625,2.00775,15.01814a1,1,0,0,1,0-1.41422l2.535-2.535a1,1,0,0,1,1.4142,0L18.05257,23.16406,40.57154.646a1,1,0,0,1,1.4142,0l2.535,2.535a1,1,0,0,1,0,1.41423Z" />
 </svg>
 `;

--- a/src/BookSettings.ts
+++ b/src/BookSettings.ts
@@ -122,7 +122,7 @@ export default class BookSettings {
 
         if (this.fontSizes.length > 1) {
             const fontSizeLabel = "<li class='font-size-label'>A</li>";
-            const fontSizeOptions = optionTemplate("font-setting", "decrease", decreaseSvg, "menuitem", "", "") + fontSizeLabel + optionTemplate("font-setting", "increase", increaseSvg, "menuitem", "", "");
+            const fontSizeOptions = optionTemplate("font-setting", "decrease", decreaseSvg, "menuitem", "", "decrease-font") + fontSizeLabel + optionTemplate("font-setting", "increase", increaseSvg, "menuitem", "", "increase-font");
             sections.push(sectionTemplate(fontSizeOptions));
         }
         sections.push(offlineTemplate);

--- a/src/ColumnsPaginatedBookView.ts
+++ b/src/ColumnsPaginatedBookView.ts
@@ -70,7 +70,7 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
     }
 
     public stop(): void {
-        document.body.style.overflow = "scroll";
+        document.body.style.overflow = "auto";
         document.body.style.position = "static";
         document.body.style.left = "";
         document.body.style.right = "";

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -356,6 +356,7 @@ export default class IFrameNavigator implements Navigator {
                 for (const link of links) {
                     const listItemElement : HTMLLIElement = document.createElement("li");
                     const linkElement: HTMLAnchorElement = document.createElement("a");
+                    linkElement.tabIndex = -1;
                     let href = "";
                     if (link.href) {
                         href = new URL(link.href, this.manifestUrl.href).href;
@@ -527,19 +528,49 @@ export default class IFrameNavigator implements Navigator {
         return element.className.indexOf(" active") !== -1;
     }
 
+    private showElement(element: HTMLDivElement | HTMLUListElement, control?: HTMLAnchorElement | HTMLButtonElement) {
+        element.className = element.className.replace(" inactive", "");
+        if (element.className.indexOf(" active") === -1) {
+            element.className += " active";
+        }
+        if (control) {
+            control.setAttribute("aria-expanded", "true");
+        }
+        // Add buttons and links in the element to the tab order.
+        const buttons = Array.prototype.slice.call(element.querySelectorAll("button"));
+        const links = Array.prototype.slice.call(element.querySelectorAll("a"));
+        for (const button of buttons) {
+            button.tabIndex = 0;
+        }
+        for (const link of links) {
+            link.tabIndex = 0;
+        }
+    }
+
+    private hideElement(element: HTMLDivElement | HTMLUListElement, control?: HTMLAnchorElement | HTMLButtonElement) {
+        element.className = element.className.replace(" active", "");
+        if (element.className.indexOf(" inactive") === -1) {
+            element.className += " inactive";
+        }
+        if (control) {
+            control.setAttribute("aria-expanded", "false");
+        }
+        // Remove buttons and links in the element from the tab order.
+        const buttons = Array.prototype.slice.call(element.querySelectorAll("button"));
+        const links = Array.prototype.slice.call(element.querySelectorAll("a"));
+        for (const button of buttons) {
+            button.tabIndex = -1;
+        }
+        for (const link of links) {
+            link.tabIndex = -1;
+        }
+    }
+
     private toggleDisplay(element: HTMLDivElement | HTMLUListElement, control?: HTMLAnchorElement | HTMLButtonElement): void {
         if (!this.isDisplayed(element)) {
-            element.className = element.className.replace(" inactive", "");
-            element.className += " active";
-            if (control) {
-                control.setAttribute("aria-expanded", "true");
-            }
+            this.showElement(element, control);
         } else {
-            element.className = element.className.replace(" active", "");
-            element.className += " inactive";
-            if (control) {
-                control.setAttribute("aria-expanded", "false");
-            }
+            this.hideElement(element, control);
         }
     }
 
@@ -711,11 +742,7 @@ export default class IFrameNavigator implements Navigator {
     }
 
     private hideTOC(): void {
-        this.contentsControl.setAttribute("aria-expanded", "false");
-        this.tocView.className = this.tocView.className.replace(" active", "");
-        if (this.tocView.className.indexOf(" inactive") === -1) {
-            this.tocView.className += " inactive";
-        }
+        this.hideElement(this.tocView, this.contentsControl);
     }
 
     private setActiveTOCItem(resource: string): void {
@@ -737,11 +764,7 @@ export default class IFrameNavigator implements Navigator {
     }
 
     private hideSettings(): void {
-        this.settingsControl.setAttribute("aria-expanded", "false");
-        this.settingsView.className = this.settingsView.className.replace(" active", "");
-        if (this.settingsView.className.indexOf(" inactive") === -1) {
-            this.settingsView.className += " inactive";
-        }
+        this.hideElement(this.settingsView, this.settingsControl);
     }
 
     private navigate(readingPosition: ReadingPosition): void {

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -24,6 +24,10 @@ const upLinkTemplate = (href: string, label: string) => `
 const template = `
   <nav class="publication">
     <div class="controls">
+      <a href="#settings-control" class="scrolling-suggestion" style="display: none">
+          We recommend scrolling mode for use with screen readers and keyboard navigation.
+          Go to settings to switch to scrolling mode.
+      </a>
       <ul class="links top active">
         <li>
           <button class="contents disabled" aria-labelledby="contents" aria-haspopup="true" aria-expanded="false">
@@ -40,7 +44,7 @@ const template = `
           </button>
         </li>
         <li>
-          <button class="settings" aria-labelledby="settings-menu" aria-expanded="false" aria-haspopup="true">
+          <button id="settings-control" class="settings" aria-labelledby="settings-menu" aria-expanded="false" aria-haspopup="true">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 186.47158 186.4716" aria-labelledby="settings" preserveAspectRatio="xMidYMid meet" role="img" class="icon">
               <title id="settings">Settings</title>
               <path d="M183.29465,117.36676l3.17693-24.131-23.52051-9.17834-4.75089-17.73081,15.78033-19.70844L159.1637,27.30789,136.04194,37.44974,120.145,28.2714,117.36676,3.17693,93.2358,0,84.05746,23.52051,66.32665,28.2714,46.61759,12.49107,27.30789,27.30789,37.44974,50.42966l-9.17834,15.897L3.17693,69.10484,0,93.2358l23.52051,9.17834L28.2714,120.145,12.49107,139.854l14.81682,19.3097,23.12177-10.14185,15.897,9.17834,2.77819,25.09447,24.131,3.17693,9.17834-23.52051L120.145,158.2002l19.70844,15.78033,19.31031-14.81682-10.14185-23.12177,9.17834-15.897ZM93.2358,129.84856A36.61276,36.61276,0,1,1,129.84856,93.2358,36.61267,36.61267,0,0,1,93.2358,129.84856Z"/>
@@ -110,6 +114,7 @@ export default class IFrameNavigator implements Navigator {
     private upUrl: URL | null;
     private upLabel: string | null;
     private iframe: HTMLIFrameElement;
+    private scrollingSuggestion: HTMLAnchorElement;
     private nextChapterLink: HTMLAnchorElement;
     private previousChapterLink: HTMLAnchorElement;
     private contentsControl: HTMLButtonElement;
@@ -184,6 +189,7 @@ export default class IFrameNavigator implements Navigator {
         this.manifestUrl = manifestUrl;
         try {
             this.iframe = HTMLUtilities.findRequiredElement(element, "iframe") as HTMLIFrameElement;
+            this.scrollingSuggestion = HTMLUtilities.findRequiredElement(element, ".scrolling-suggestion") as HTMLAnchorElement;
             this.nextChapterLink = HTMLUtilities.findRequiredElement(element, "a[rel=next]") as HTMLAnchorElement;
             this.previousChapterLink = HTMLUtilities.findRequiredElement(element, "a[rel=prev]") as HTMLAnchorElement;
             this.contentsControl = HTMLUtilities.findRequiredElement(element, "button.contents") as HTMLButtonElement;
@@ -219,6 +225,10 @@ export default class IFrameNavigator implements Navigator {
             this.cacher.onStatusUpdate(this.updateOfflineCacheStatus.bind(this));
             this.enableOffline();
 
+            if (this.scroller && (this.settings.getSelectedView() !== this.scroller)) {
+                this.scrollingSuggestion.style.display = "block";
+            }
+
             return await this.loadManifest();
         } catch (err) {
             // There's a mismatch between the template and the selectors above,
@@ -248,6 +258,7 @@ export default class IFrameNavigator implements Navigator {
     private updateBookView(): void {
         const doNothing = () => {};
         if (this.settings.getSelectedView() === this.paginator) {
+            this.scrollingSuggestion.style.display = "block";
             document.body.onscroll = () => {};
             this.chapterTitle.style.display = "inline";
             this.chapterPosition.style.display = "inline";
@@ -265,6 +276,7 @@ export default class IFrameNavigator implements Navigator {
                 this.toggleDisplay(this.linksBottom);
             }
         } else if (this.settings.getSelectedView() === this.scroller) {
+            this.scrollingSuggestion.style.display = "none";
             document.body.onscroll = () => {
                 this.saveCurrentReadingPosition();
                 if (this.scroller && this.scroller.atBottom()) {

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -36,16 +36,16 @@ const template = `
               <rect y="76" width="33" height="28"/>
               <rect y="152" width="33" height="28"/>
             </svg>
-            <span class="setting-text contents">Contents</span>
+            <span class="setting-text contents" id="contents">Contents</span>
           </button>
         </li>
         <li>
-          <button class="settings" aria-labelledby="settings-menu" aria-expanded="false" aria-haspopup="true">
+          <button class="settings" aria-labelledby="settings" aria-expanded="false" aria-haspopup="true">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 186.47158 186.4716" aria-labelledby="settings" preserveAspectRatio="xMidYMid meet" role="img" class="icon">
               <title id="settings">Settings</title>
               <path d="M183.29465,117.36676l3.17693-24.131-23.52051-9.17834-4.75089-17.73081,15.78033-19.70844L159.1637,27.30789,136.04194,37.44974,120.145,28.2714,117.36676,3.17693,93.2358,0,84.05746,23.52051,66.32665,28.2714,46.61759,12.49107,27.30789,27.30789,37.44974,50.42966l-9.17834,15.897L3.17693,69.10484,0,93.2358l23.52051,9.17834L28.2714,120.145,12.49107,139.854l14.81682,19.3097,23.12177-10.14185,15.897,9.17834,2.77819,25.09447,24.131,3.17693,9.17834-23.52051L120.145,158.2002l19.70844,15.78033,19.31031-14.81682-10.14185-23.12177,9.17834-15.897ZM93.2358,129.84856A36.61276,36.61276,0,1,1,129.84856,93.2358,36.61267,36.61267,0,0,1,93.2358,129.84856Z"/>
               </svg>
-            <span class="setting-text settings">Settings</span>
+            <span class="setting-text settings" aria-labelledby="settings">Settings</span>
           </button>
         </li>
       </ul>

--- a/src/styles/sass/_settings.scss
+++ b/src/styles/sass/_settings.scss
@@ -2,6 +2,7 @@
 // Settings View Sytles     //
 //////////////////////////////
 .settings-view {
+  overflow: hidden;
 
   > .settings-menu {
     background-color: $mta-white;
@@ -12,6 +13,10 @@
     padding: 0 1rem;
     position: relative;
     width: 100%;
+
+    @media screen and (min-width: 30rem) {
+      height: 3.5rem;
+    }
 
     @media (min-width: 60rem) {
       width: 100%;
@@ -30,10 +35,25 @@
         //font-size: 1vw;
       }
 
+      svg.checkedIcon {
+        // styles the icon that appears next to paginate/scrolling buttons
+        // set a default color
+        color: $mta-white;
+        display: none;
+        fill: $mta-white;
+        height: 1rem;
+        width: 0.6875rem;
+      }
+
       // reverse the active state
       &.active {
         color: $nypl-white;
         background-color: $mta-green;
+
+        svg.checkedIcon {
+          display: inline-block;
+        }
+
       }
     }
 
@@ -47,9 +67,55 @@
       vertical-align: text-bottom;
       width: 100%;
 
+      @media screen and (min-width: 30rem) {
+        margin: 0.7rem 0.3rem 0.5rem 0;
+      }
+
       @media (min-width: 60rem) {
         display: inline-block;
         margin-right: 1%;
+      }
+    }
+
+    > li:nth-child(1) { // the parent of paginate/scrolling buttons
+
+      @media screen and (min-width: 30rem) {
+        width: 40%;
+        margin-left: 20%;
+        text-align: right;
+      }
+
+      @media screen and (min-width: 60rem) {
+        margin-left: 0;
+        width: 85vw;
+        text-align: right;
+      }
+
+      @media screen and (min-width: 87.5rem) {
+        width: 89.75vw;
+      }
+    }
+
+    > li:nth-child(2) { // the type / font increase & decrease buttons
+
+      @media screen and (min-width: 30rem) {
+        width: 20%;
+        position: relative;
+        text-align: left;
+        top: 0.2rem;
+
+        .settings-options {
+          padding-top: 0.15rem;
+        }
+
+        .font-size-label {
+          top: -0.17rem;
+        }
+      }
+
+      @media screen and (min-width: 60rem) {
+        width: auto;
+        text-align: right;
       }
     }
 
@@ -94,12 +160,6 @@
       }
 
       .icon {
-        //background-color: $mta-green;
-        //border: 0;
-        //border-radius: 3rem;
-        //color: $mta-white;
-        //font-size: 1.3rem;
-        //padding: 0.2rem 0.69rem;
         color: $mta-green;
         fill: $mta-green;
         height: 1.75rem;
@@ -113,9 +173,9 @@
 
       .font-size-label {
         color: $mta-green;
-        font-size: 1.125rem; // giving this a value even though it gets set by the application... seems like a good idea.
+        font-size: 1.5rem;
         position: relative;
-        top: -0.5rem;
+        top: -0.17rem;
         margin: auto 0.4rem;
       }
 

--- a/src/styles/sass/_settings.scss
+++ b/src/styles/sass/_settings.scss
@@ -85,7 +85,7 @@
     > li:nth-child(1) { // the parent of paginate/scrolling buttons
 
       @media screen and (min-width: 30rem) {
-        width: 40%;
+        width: 45%;
         margin-left: 20%;
         text-align: right;
       }

--- a/src/styles/sass/_settings.scss
+++ b/src/styles/sass/_settings.scss
@@ -37,12 +37,13 @@
 
       svg.checkedIcon {
         // styles the icon that appears next to paginate/scrolling buttons
-        // set a default color
+        // set a default color of $mta-white, since this should always
+        // show up on a dark color background.
         color: $mta-white;
         display: none;
         fill: $mta-white;
-        height: 1rem;
-        width: 0.6875rem;
+        height: 0.9rem;
+        width: 0.5875rem;
       }
 
       // reverse the active state
@@ -52,6 +53,10 @@
 
         svg.checkedIcon {
           display: inline-block;
+          margin: 0 0 0 0.5rem;
+          position: relative;
+          top: -0.01rem;
+          vertical-align: text-bottom;
         }
 
       }

--- a/src/styles/sass/main.scss
+++ b/src/styles/sass/main.scss
@@ -310,6 +310,7 @@ a {
 
   &.inactive {
     transition: opacity 300ms cubic-bezier(0, 0.03, 0.63, 0.99);
+    height: 0;
   }
 
   &.active {

--- a/src/styles/sass/main.scss
+++ b/src/styles/sass/main.scss
@@ -124,7 +124,7 @@ a {
         //z-index: 2000;
       }
 
-      li:nth-child(1) { // this is the back arrow
+      > li:nth-child(1) { // this is the back arrow
         position: relative;
         text-align: left;
         right: 0;
@@ -137,7 +137,7 @@ a {
       }
 
       @media screen and (min-width: 30rem) {
-        li:nth-child(1) {
+        > li:nth-child(1) {
           background-color: $nypl-white;
           display: inline-block;
           margin: 0.175rem 0 0 0.625rem;
@@ -160,7 +160,7 @@ a {
       }
     }
 
-      li:nth-child(2) { // contents button
+      > li:nth-child(2) { // contents button
         margin: 0 0 0 65vw;
 
         @media (min-width: 30rem) {
@@ -176,7 +176,7 @@ a {
         }
       }
 
-      li:nth-child(3) {
+      > li:nth-child(3) {
         //float: right;
       }
     } // / .top
@@ -303,6 +303,7 @@ a {
   top: 3rem;
   width: 100%;
   -webkit-overflow-scrolling: touch;
+  text-align: left;
 
   .disabled {
     background-color: darken($mta-green, 20%);

--- a/src/styles/sass/main.scss
+++ b/src/styles/sass/main.scss
@@ -349,5 +349,26 @@ iframe {
   }
 }
 
+.scrolling-suggestion {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  background-color: white;
+  margin: 5px;
+  padding: 5px 10px;
+  z-index: 4000;
+
+  &:focus {
+    left: auto;
+    width: auto;
+    height: auto;
+    overflow: visible;
+    top: 5px;
+  }
+}
+
 @import "toc";
 @import "settings";

--- a/test/BookSettingsTest.ts
+++ b/test/BookSettingsTest.ts
@@ -116,9 +116,11 @@ describe("BookSettings", () => {
             settings.renderControls(element);
 
             let view1Button = element.querySelector("button[class='view1 active']") as HTMLButtonElement;
-            expect(view1Button.innerHTML).to.equal("View 1");
+            expect(view1Button.innerHTML).to.contain("View 1");
+            expect(view1Button.getAttribute("aria-label")).to.equal("View 1 mode enabled");
             let view2Button = element.querySelector("button[class=view2]") as HTMLButtonElement;
-            expect(view2Button.innerHTML).to.equal("View 2");
+            expect(view2Button.innerHTML).to.contain("View 2");
+            expect(view2Button.getAttribute("aria-label")).to.equal("View 2 mode disabled");
 
             // If there's no views or only 1 view, views don't show up in the settings.
 
@@ -161,6 +163,10 @@ describe("BookSettings", () => {
             expect(view1Button.className).not.to.contain("active");
             expect(view2Button.className).to.contain("active");
 
+            expect(view1Button.getAttribute("aria-label")).to.equal("View 1 mode disabled");
+            expect(view2Button.getAttribute("aria-label")).to.equal("View 2 mode enabled");
+
+
             click(view1Button);
             await pause();
 
@@ -179,6 +185,9 @@ describe("BookSettings", () => {
 
             expect(view1Button.className).to.contain("active");
             expect(view2Button.className).not.to.contain("active");
+
+            expect(view1Button.getAttribute("aria-label")).to.equal("View 1 mode enabled");
+            expect(view2Button.getAttribute("aria-label")).to.equal("View 2 mode disabled");
         });
 
         it("renders font size increase and decrease buttons", async () => {

--- a/test/ColumnsPaginatedBookViewTests.ts
+++ b/test/ColumnsPaginatedBookViewTests.ts
@@ -79,13 +79,13 @@ describe("ColumnsPaginatedBookView", () => {
         it("should remove styling from iframe and iframe body", () => {
             paginator.start(0);
 
-            expect(document.body.style.overflow).not.to.equal("scroll");
+            expect(document.body.style.overflow).not.to.equal("auto");
             expect(iframe.style.height).not.to.equal("");
             expect(iframe.contentDocument.body.style.columnWidth).not.to.equal("");
 
             paginator.stop();
 
-            expect(document.body.style.overflow).to.equal("scroll");
+            expect(document.body.style.overflow).to.equal("auto");
             expect(iframe.style.height).to.equal("");
             expect(iframe.contentDocument.body.style.columnWidth).to.equal("");
         });

--- a/test/IFrameNavigatorTests.ts
+++ b/test/IFrameNavigatorTests.ts
@@ -919,22 +919,41 @@ describe("IFrameNavigator", () => {
             const iframe = element.querySelector("iframe") as HTMLIFrameElement;
             const toc = element.querySelector(".contents-view") as HTMLDivElement; 
             const contentsControl = element.querySelector("button.contents") as HTMLButtonElement;
+
+            const links = toc.querySelectorAll("li > a");
+            const link1 = links[0] as HTMLAnchorElement;
+            const link2 = links[1] as HTMLAnchorElement;
+            const link3 = links[2] as HTMLAnchorElement;
+            const link4 = links[3] as HTMLAnchorElement;
+
             expect(toc.className).to.contain(" active");
             expect(toc.className).not.to.contain(" inactive");
             expect(contentsControl.getAttribute("aria-expanded")).to.equal("true");
             expect(iframe.src).to.equal("http://example.com/start.html");
+            expect(link1.tabIndex).to.equal(0);
+            expect(link2.tabIndex).to.equal(0);
+            expect(link3.tabIndex).to.equal(0);
+            expect(link4.tabIndex).to.equal(0);
 
             click(contentsControl);
             expect(toc.className).to.contain(" inactive");
             expect(toc.className).not.to.contain(" active");
             expect(contentsControl.getAttribute("aria-expanded")).to.equal("false");
             expect(iframe.src).to.equal("http://example.com/start.html");
+            expect(link1.tabIndex).to.equal(-1);
+            expect(link2.tabIndex).to.equal(-1);
+            expect(link3.tabIndex).to.equal(-1);
+            expect(link4.tabIndex).to.equal(-1);
 
             click(contentsControl);
             expect(toc.className).to.contain(" active");
             expect(toc.className).not.to.contain(" inactive");
             expect(contentsControl.getAttribute("aria-expanded")).to.equal("true");
             expect(iframe.src).to.equal("http://example.com/start.html");
+            expect(link1.tabIndex).to.equal(0);
+            expect(link2.tabIndex).to.equal(0);
+            expect(link3.tabIndex).to.equal(0);
+            expect(link4.tabIndex).to.equal(0);
         });
 
         it("should hide when other navigation links are clicked", async () => {
@@ -942,11 +961,21 @@ describe("IFrameNavigator", () => {
             const toc = element.querySelector(".contents-view") as HTMLDivElement;
             const contentsControl = element.querySelector("button.contents") as HTMLButtonElement;
 
+            const links = toc.querySelectorAll("li > a");
+            const link1 = links[0] as HTMLAnchorElement;
+            const link2 = links[1] as HTMLAnchorElement;
+            const link3 = links[2] as HTMLAnchorElement;
+            const link4 = links[3] as HTMLAnchorElement;
+
             iframe.src = "http://example.com/item-1.html";
             await pause();
             expect(toc.className).to.contain(" active");
             expect(toc.className).not.to.contain(" inactive");
             expect(contentsControl.getAttribute("aria-expanded")).to.equal("true");
+            expect(link1.tabIndex).to.equal(0);
+            expect(link2.tabIndex).to.equal(0);
+            expect(link3.tabIndex).to.equal(0);
+            expect(link4.tabIndex).to.equal(0);
 
             const nextChapterLink = element.querySelector("a[rel=next]") as HTMLAnchorElement;
             click(nextChapterLink);
@@ -954,11 +983,19 @@ describe("IFrameNavigator", () => {
             expect(toc.className).to.contain(" inactive");
             expect(toc.className).not.to.contain(" active");
             expect(contentsControl.getAttribute("aria-expanded")).to.equal("false");
+            expect(link1.tabIndex).to.equal(-1);
+            expect(link2.tabIndex).to.equal(-1);
+            expect(link3.tabIndex).to.equal(-1);
+            expect(link4.tabIndex).to.equal(-1);
 
             click(contentsControl);
             expect(toc.className).to.contain(" active");
             expect(toc.className).not.to.contain(" inactive");
             expect(contentsControl.getAttribute("aria-expanded")).to.equal("true");
+            expect(link1.tabIndex).to.equal(0);
+            expect(link2.tabIndex).to.equal(0);
+            expect(link3.tabIndex).to.equal(0);
+            expect(link4.tabIndex).to.equal(0);
 
             const previousChapterLink = element.querySelector("a[rel=prev]") as HTMLAnchorElement;
             click(previousChapterLink);
@@ -966,6 +1003,10 @@ describe("IFrameNavigator", () => {
             expect(toc.className).to.contain(" inactive");
             expect(toc.className).not.to.contain(" active");
             expect(contentsControl.getAttribute("aria-expanded")).to.equal("false");
+            expect(link1.tabIndex).to.equal(-1);
+            expect(link2.tabIndex).to.equal(-1);
+            expect(link3.tabIndex).to.equal(-1);
+            expect(link4.tabIndex).to.equal(-1);
         });
 
         it("should navigate to a toc item", async () => {
@@ -985,17 +1026,23 @@ describe("IFrameNavigator", () => {
             expect(toc.className).not.to.contain(" active");
             expect(contentsControl.getAttribute("aria-expanded")).to.equal("false");
             expect(iframe.src).to.equal("http://example.com/item-1.html");
+            expect(link1.tabIndex).to.equal(-1);
+            expect(link2.tabIndex).to.equal(-1);
 
             click(contentsControl);
             expect(toc.className).to.contain(" active");
             expect(toc.className).not.to.contain(" inactive");
             expect(contentsControl.getAttribute("aria-expanded")).to.equal("true");
+            expect(link1.tabIndex).to.equal(0);
+            expect(link2.tabIndex).to.equal(0);
 
             click(link2);
             expect(toc.className).to.contain(" inactive");
             expect(toc.className).not.to.contain(" active");
             expect(contentsControl.getAttribute("aria-expanded")).to.equal("false");
             expect(iframe.src).to.equal("http://example.com/subitem-1.html");
+            expect(link1.tabIndex).to.equal(-1);
+            expect(link2.tabIndex).to.equal(-1);
 
             await pause();
             expect(saveLastReadingPosition.callCount).to.equal(3);
@@ -1007,6 +1054,8 @@ describe("IFrameNavigator", () => {
             expect(toc.className).not.to.contain(" active");
             expect(contentsControl.getAttribute("aria-expanded")).to.equal("false");
             expect(iframe.src).to.equal("http://example.com/subitem-1.html");
+            expect(link1.tabIndex).to.equal(-1);
+            expect(link2.tabIndex).to.equal(-1);
 
             await pause();
             expect(saveLastReadingPosition.callCount).to.equal(3);
@@ -1040,39 +1089,53 @@ describe("IFrameNavigator", () => {
             const iframe = element.querySelector("iframe") as HTMLIFrameElement;
             const settings = element.querySelector(".settings-view") as HTMLDivElement;
             const settingsControl = element.querySelector("button.settings") as HTMLButtonElement;
+
+            settings.innerHTML = "<button tabindex=-1>Test</button>";
+            const button = settings.querySelector("button") as HTMLButtonElement;
+
             expect(settings.className).to.contain(" inactive");
             expect(settingsControl.getAttribute("aria-expanded")).to.equal("false");
             expect(iframe.src).to.equal("http://example.com/start.html");
+            expect(button.tabIndex).to.equal(-1);
 
             click(settingsControl);
             expect(settings.className).to.contain(" active");
             expect(settings.className).not.to.contain(" inactive");
             expect(settingsControl.getAttribute("aria-expanded")).to.equal("true");
             expect(iframe.src).to.equal("http://example.com/start.html");
+            expect(button.tabIndex).to.equal(0);
 
             click(settingsControl);
             expect(settings.className).to.contain(" inactive");
             expect(settings.className).not.to.contain(" active");
             expect(settingsControl.getAttribute("aria-expanded")).to.equal("false");
             expect(iframe.src).to.equal("http://example.com/start.html");
+            expect(button.tabIndex).to.equal(-1);
         });
 
         it("should hide when settings view is clicked", async () => {
             const settings = element.querySelector(".settings-view") as HTMLDivElement;
             const settingsControl = element.querySelector("button.settings") as HTMLButtonElement;
+
+            settings.innerHTML = "<button tabindex=-1>Test</button>";
+            const button = settings.querySelector("button") as HTMLButtonElement;
+
             expect(settings.className).to.contain(" inactive");
             expect(settings.className).not.to.contain(" active");
             expect(settingsControl.getAttribute("aria-expanded")).to.equal("false");
+            expect(button.tabIndex).to.equal(-1);
 
             click(settingsControl);
             expect(settings.className).to.contain(" active");
             expect(settings.className).not.to.contain(" inactive");
             expect(settingsControl.getAttribute("aria-expanded")).to.equal("true");
+            expect(button.tabIndex).to.equal(0);
 
             click(settings);
             expect(settings.className).to.contain(" inactive");
             expect(settings.className).not.to.contain(" active");
             expect(settingsControl.getAttribute("aria-expanded")).to.equal("false");
+            expect(button.tabIndex).to.equal(-1);
         });
     });
 

--- a/test/IFrameNavigatorTests.ts
+++ b/test/IFrameNavigatorTests.ts
@@ -1075,4 +1075,35 @@ describe("IFrameNavigator", () => {
             expect(settingsControl.getAttribute("aria-expanded")).to.equal("false");
         });
     });
+
+    describe("scrolling suggestion", () => {
+        it("should show in paginated mode but not scrolling mode", async () => {
+            let scrollingSuggestion = element.querySelector(".scrolling-suggestion") as HTMLAnchorElement;
+            expect(scrollingSuggestion.style.display).not.to.equal("none");
+
+            getSelectedView.returns(scroller);            
+            navigator = await IFrameNavigator.create(element, new URL("http://example.com/manifest.json"), store, cacher, settings, annotator, paginator, scroller, eventHandler);
+            scrollingSuggestion = element.querySelector(".scrolling-suggestion") as HTMLAnchorElement;
+            
+            expect(scrollingSuggestion.style.display).to.equal("none");
+        });
+
+        it("should hide when book view changes to scroller and show when it changes to paginator", async () => {
+            let scrollingSuggestion = element.querySelector(".scrolling-suggestion") as HTMLAnchorElement;
+            const updateBookView = onViewChange.args[0][0];
+
+            updateBookView();
+            expect(scrollingSuggestion.style.display).not.to.equal("none");
+
+            getSelectedView.returns(scroller);
+
+            updateBookView();
+            expect(scrollingSuggestion.style.display).to.equal("none");
+
+            getSelectedView.returns(paginator);
+
+            updateBookView();
+            expect(scrollingSuggestion.style.display).not.to.equal("none");
+        });
+    });
 });


### PR DESCRIPTION
This fixes #44 
This fixes #78 
This fixes #48 
This fixes #46

I added a message as the first tab item on the page that says 
```
We recommend scrolling mode for use with screen readers and keyboard navigation.
Go to settings to switch to scrolling mode.
```
and links to the button that opens the settings menu. 

In addition, I fixed the tab index on links and buttons in the menus so that it's 0 when the menu is displayed and -1 when the menu is hidden.