### PR TITLE
Improved behavior when using pinch-to-zoom on iOS.

### DIFF
--- a/src/BrowserUtilities.ts
+++ b/src/BrowserUtilities.ts
@@ -1,0 +1,14 @@
+/** Returns the current width of the document. */
+export function getWidth(): number {
+    return document.documentElement.clientWidth;
+}
+
+/** Returns the current height of the document. */
+export function getHeight(): number {
+    return document.documentElement.clientHeight;
+}
+
+/** Returns true if the browser is zoomed in with pinch-to-zoom on mobile. */
+export function isZoomed(): boolean {
+    return (getWidth() !== window.innerWidth);
+}

--- a/src/ColumnsPaginatedBookView.ts
+++ b/src/ColumnsPaginatedBookView.ts
@@ -1,5 +1,6 @@
 import PaginatedBookView from "./PaginatedBookView";
 import * as HTMLUtilities from "./HTMLUtilities";
+import * as BrowserUtilities from "./BrowserUtilities";
 
 export default class ColumnsPaginatedBookView implements PaginatedBookView {
     public readonly name = "columns-paginated-view";
@@ -45,7 +46,7 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
         // all the vendor-prefixed attributes.
         const body = HTMLUtilities.findRequiredElement(this.bookElement.contentDocument, "body") as any;
 
-        const width = (document.documentElement.clientWidth - this.sideMargin * 2) + "px"
+        const width = (BrowserUtilities.getWidth() - this.sideMargin * 2) + "px"
         body.style.columnWidth = width;
         body.style.WebkitColumnWidth = width;
         body.style.MozColumnWidth = width;
@@ -60,7 +61,7 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
         body.style.marginBottom = "0px";
         this.bookElement.contentDocument.documentElement.style.height = this.height + "px";
         this.bookElement.style.height = this.height + "px";
-        this.bookElement.style.width = document.documentElement.clientWidth + "px";
+        this.bookElement.style.width = BrowserUtilities.getWidth() + "px";
 
         const images = body.querySelectorAll("img");
         for (const image of images) {

--- a/src/ColumnsPaginatedBookView.ts
+++ b/src/ColumnsPaginatedBookView.ts
@@ -45,7 +45,7 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
         // all the vendor-prefixed attributes.
         const body = HTMLUtilities.findRequiredElement(this.bookElement.contentDocument, "body") as any;
 
-        const width = (window.innerWidth - this.sideMargin * 2) + "px"
+        const width = (document.documentElement.clientWidth - this.sideMargin * 2) + "px"
         body.style.columnWidth = width;
         body.style.WebkitColumnWidth = width;
         body.style.MozColumnWidth = width;
@@ -60,7 +60,7 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
         body.style.marginBottom = "0px";
         this.bookElement.contentDocument.documentElement.style.height = this.height + "px";
         this.bookElement.style.height = this.height + "px";
-        this.bookElement.style.width = window.innerWidth + "px";
+        this.bookElement.style.width = document.documentElement.clientWidth + "px";
 
         const images = body.querySelectorAll("img");
         for (const image of images) {

--- a/src/EventHandler.ts
+++ b/src/EventHandler.ts
@@ -1,3 +1,5 @@
+import * as BrowserUtilities from "./BrowserUtilities";
+
 export default class EventHandler {
     private pendingMouseEventStart: MouseEvent | null = null;
     private pendingMouseEventEnd: MouseEvent | null = null;
@@ -43,16 +45,12 @@ export default class EventHandler {
         return !!('ontouchstart' in window || navigator.maxTouchPoints);
     }
 
-    private isZoomed() {
-        return (window.innerWidth !== document.documentElement.clientWidth);
-    }
-
     private handleMouseEventStart = (event: MouseEvent): void => {
         this.pendingMouseEventStart = event;
     }
 
     private handleTouchEventStart = (event: TouchEvent): void => {
-        if (this.isZoomed()) {
+        if (BrowserUtilities.isZoomed()) {
             return;
         }
 
@@ -99,7 +97,7 @@ export default class EventHandler {
     }
 
     private handleTouchEventEnd = (event: TouchEvent): void => {
-        if (this.isZoomed()) {
+        if (BrowserUtilities.isZoomed()) {
             return;
         }
 

--- a/src/EventHandler.ts
+++ b/src/EventHandler.ts
@@ -43,11 +43,19 @@ export default class EventHandler {
         return !!('ontouchstart' in window || navigator.maxTouchPoints);
     }
 
+    private isZoomed() {
+        return (window.innerWidth !== document.documentElement.clientWidth);
+    }
+
     private handleMouseEventStart = (event: MouseEvent): void => {
         this.pendingMouseEventStart = event;
     }
 
     private handleTouchEventStart = (event: TouchEvent): void => {
+        if (this.isZoomed()) {
+            return;
+        }
+
         if (event.changedTouches.length !== 1) {
             // This is a multi-touch event. Ignore.
             return;
@@ -91,6 +99,10 @@ export default class EventHandler {
     }
 
     private handleTouchEventEnd = (event: TouchEvent): void => {
+        if (this.isZoomed()) {
+            return;
+        }
+
         if (event.changedTouches.length !== 1) {
             // This is a multi-touch event. Ignore.
             return;

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -663,8 +663,8 @@ export default class IFrameNavigator implements Navigator {
         const fontSizeNumber = parseInt(fontSize.slice(0, -2));
         let sideMargin = fontSizeNumber * 2;
 
-        if (window.innerWidth > fontSizeNumber * 45) {
-            const extraMargin = Math.floor((window.innerWidth - fontSizeNumber * 40) / 2);
+        if (document.documentElement.clientWidth > fontSizeNumber * 45) {
+            const extraMargin = Math.floor((document.documentElement.clientWidth - fontSizeNumber * 40) / 2);
             sideMargin = sideMargin + extraMargin;
         }
         if (this.paginator) {
@@ -703,10 +703,10 @@ export default class IFrameNavigator implements Navigator {
         }
 
         if (this.paginator) {
-            this.paginator.height = (window.innerHeight - topHeight - bottomHeight - 10);
+            this.paginator.height = (document.documentElement.clientHeight - topHeight - bottomHeight - 10);
         }
         if (this.scroller) {
-            this.scroller.height = (window.innerHeight - topHeight - bottomHeight - 10);
+            this.scroller.height = (document.documentElement.clientHeight - topHeight - bottomHeight - 10);
         }
 
         selectedView.goToPosition(oldPosition);

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -9,6 +9,7 @@ import Manifest from "./Manifest";
 import { Link } from "./Manifest";
 import BookSettings from "./BookSettings";
 import EventHandler from "./EventHandler";
+import * as BrowserUtilities from "./BrowserUtilities";
 import * as HTMLUtilities from "./HTMLUtilities";
 
 const upLinkTemplate = (href: string, label: string, ariaLabel: string) => `
@@ -810,8 +811,8 @@ export default class IFrameNavigator implements Navigator {
         const fontSizeNumber = parseInt(fontSize.slice(0, -2));
         let sideMargin = fontSizeNumber * 2;
 
-        if (document.documentElement.clientWidth > fontSizeNumber * 45) {
-            const extraMargin = Math.floor((document.documentElement.clientWidth - fontSizeNumber * 40) / 2);
+        if (BrowserUtilities.getWidth() > fontSizeNumber * 45) {
+            const extraMargin = Math.floor((BrowserUtilities.getWidth() - fontSizeNumber * 40) / 2);
             sideMargin = sideMargin + extraMargin;
         }
         if (this.paginator) {
@@ -850,10 +851,10 @@ export default class IFrameNavigator implements Navigator {
         }
 
         if (this.paginator) {
-            this.paginator.height = (document.documentElement.clientHeight - topHeight - bottomHeight - 10);
+            this.paginator.height = (BrowserUtilities.getHeight() - topHeight - bottomHeight - 10);
         }
         if (this.scroller) {
-            this.scroller.height = (document.documentElement.clientHeight - topHeight - bottomHeight - 10);
+            this.scroller.height = (BrowserUtilities.getHeight() - topHeight - bottomHeight - 10);
         }
 
         selectedView.goToPosition(oldPosition);

--- a/src/ScrollingBookView.ts
+++ b/src/ScrollingBookView.ts
@@ -12,11 +12,11 @@ export default class ScrollingBookView implements BookView {
     private setIFrameSize(): void {
         // Remove previous iframe height so body scroll height will be accurate.
         this.bookElement.style.height = "";
-        this.bookElement.style.width = window.innerWidth + "px";
+        this.bookElement.style.width = document.documentElement.clientWidth + "px";
 
         const body = HTMLUtilities.findRequiredElement(this.bookElement.contentDocument, "body") as HTMLBodyElement;
 
-        body.style.width = (window.innerWidth - this.sideMargin * 2) + "px";
+        body.style.width = (document.documentElement.clientWidth - this.sideMargin * 2) + "px";
         body.style.marginLeft = this.sideMargin + "px";
         body.style.marginRight = this.sideMargin + "px";
 
@@ -44,7 +44,7 @@ export default class ScrollingBookView implements BookView {
     }
 
     public atBottom(): boolean {
-        return (document.body.scrollHeight - document.body.scrollTop) === window.innerHeight;
+        return (document.body.scrollHeight - document.body.scrollTop) === document.documentElement.clientHeight;
     }
 
     public goToPosition(position: number) {

--- a/src/ScrollingBookView.ts
+++ b/src/ScrollingBookView.ts
@@ -1,4 +1,5 @@
 import BookView from "./BookView";
+import * as BrowserUtilities from "./BrowserUtilities";
 import * as HTMLUtilities from "./HTMLUtilities";
 
 export default class ScrollingBookView implements BookView {
@@ -12,11 +13,11 @@ export default class ScrollingBookView implements BookView {
     private setIFrameSize(): void {
         // Remove previous iframe height so body scroll height will be accurate.
         this.bookElement.style.height = "";
-        this.bookElement.style.width = document.documentElement.clientWidth + "px";
+        this.bookElement.style.width = BrowserUtilities.getWidth() + "px";
 
         const body = HTMLUtilities.findRequiredElement(this.bookElement.contentDocument, "body") as HTMLBodyElement;
 
-        body.style.width = (document.documentElement.clientWidth - this.sideMargin * 2) + "px";
+        body.style.width = (BrowserUtilities.getWidth() - this.sideMargin * 2) + "px";
         body.style.marginLeft = this.sideMargin + "px";
         body.style.marginRight = this.sideMargin + "px";
 
@@ -44,7 +45,7 @@ export default class ScrollingBookView implements BookView {
     }
 
     public atBottom(): boolean {
-        return (document.body.scrollHeight - document.body.scrollTop) === document.documentElement.clientHeight;
+        return (document.body.scrollHeight - document.body.scrollTop) === BrowserUtilities.getHeight();
     }
 
     public goToPosition(position: number) {

--- a/test/BrowserUtilitiesTests.ts
+++ b/test/BrowserUtilitiesTests.ts
@@ -1,0 +1,36 @@
+import { expect } from "chai";
+
+import * as BrowserUtilities from "../src/BrowserUtilities";
+
+describe("HTMLUtilities", () => {
+    beforeEach(() => {
+        (window as any).innerWidth = 50;
+        (window as any).innerHeight = 10;
+        (document.documentElement as any).clientWidth = 500;
+        (document.documentElement as any).clientHeight = 800;
+    });
+
+    describe("#getWidth", () => {
+        it("should return current width", () => {
+            expect(BrowserUtilities.getWidth()).to.equal(500);
+            (document.documentElement as any).clientWidth = 100;
+            expect(BrowserUtilities.getWidth()).to.equal(100);
+        });
+    });
+
+    describe("#getHeight", () => {
+        it("should return current height", () => {
+            expect(BrowserUtilities.getHeight()).to.equal(800);
+            (document.documentElement as any).clientHeight = 100;
+            expect(BrowserUtilities.getHeight()).to.equal(100);
+        });
+    });
+
+    describe("#isZoomed", () => {
+        it("should return true if document width differs from window width", () => {
+            expect(BrowserUtilities.isZoomed()).to.equal(true);
+            (document.documentElement as any).clientWidth = 50;
+            expect(BrowserUtilities.isZoomed()).to.equal(false);
+        });
+    });
+});

--- a/test/ColumnsPaginatedBookViewTests.ts
+++ b/test/ColumnsPaginatedBookViewTests.ts
@@ -38,7 +38,7 @@ describe("ColumnsPaginatedBookView", () => {
         });
 
         it("should set iframe and iframe body width and height and column width based on window width and set height", () => {
-            (window as any).innerWidth = 100;
+            (document.documentElement as any).clientWidth = 100;
             paginator.start(0);
             const body = iframe.contentDocument.body;
             expect(iframe.style.height).to.equal("200px");
@@ -50,7 +50,7 @@ describe("ColumnsPaginatedBookView", () => {
         });
 
         it("should set max width and height on image in iframe", () => {
-            (window as any).innderWidth = 100;
+            (document.documentElement as any).clientWidth = 100;
             const body = iframe.contentDocument.body;
             const image  = window.document.createElement("img");
             body.appendChild(image);

--- a/test/EventHandlerTests.ts
+++ b/test/EventHandlerTests.ts
@@ -93,6 +93,7 @@ describe("EventHandler", () => {
 
         (window as any).devicePixelRatio = 2;
         (window as any).innerWidth = 1024;
+        (document.documentElement as any).clientWidth = 1024;
     });
 
     describe("#setupEvents", () => {
@@ -224,6 +225,16 @@ describe("EventHandler", () => {
                 window.ontouchstart = () => {};
 
                 eventHandler.setupEvents(element);
+            });
+
+            it("should do nothing if the window is zoomed in", async () => {
+                (window as any).innerWidth = 2048;
+                event("touchstart");
+                event("touchend");
+
+                await pause(250);
+
+                expect(onLeftTap.callCount).to.equal(0);
             });
 
             it("should do nothing if there's an end event without a start event", async () => {

--- a/test/IFrameNavigatorTests.ts
+++ b/test/IFrameNavigatorTests.ts
@@ -247,7 +247,7 @@ describe("IFrameNavigator", () => {
 
         // The element must be in a document for iframe load events to work.
         window.document.body.appendChild(element);
-        (window as any).innerWidth = 1024;
+        (document.documentElement as any).clientWidth = 1024;
         navigator = await IFrameNavigator.create(element, new URL("http://example.com/manifest.json"), store, cacher, settings, annotator, paginator, scroller, eventHandler);
     });
 
@@ -365,7 +365,7 @@ describe("IFrameNavigator", () => {
         it("should give the settings a function to call when the font size changes", async () => {
             // If the window is wide enough, the view gets a large margin.
             // This should've been set before the test started.
-            expect(window.innerWidth).to.equal(1024);
+            expect(document.documentElement.clientWidth).to.equal(1024);
 
             expect(onFontSizeChange.callCount).to.equal(1);
             const iframe = element.querySelector("iframe") as HTMLIFrameElement;
@@ -387,7 +387,7 @@ describe("IFrameNavigator", () => {
 
             // If the window is small, the view gets a smaller margin, but still based
             // on the font size.
-            (window as any).innerWidth = 100;
+            (document.documentElement as any).clientWidth = 100;
 
             getSelectedFontSize.returns("14px");
             updateFontSize();
@@ -823,7 +823,7 @@ describe("IFrameNavigator", () => {
             const infoBottom = element.querySelector(".info.bottom") as HTMLDivElement;
             (linksTop as any).clientHeight = 10;
             (linksBottom as any).clientHeight = 20;
-            (window as any).innerHeight = 100;
+            (document.documentElement as any).clientHeight = 100;
 
             iframe.src = "http://example.com/item-1.html";
             await pause();

--- a/test/ScrollingBookViewTests.ts
+++ b/test/ScrollingBookViewTests.ts
@@ -34,7 +34,7 @@ describe("ScrollingBookView", () => {
             scroller.sideMargin = 11;
             scroller.height = 70;
             (iframe.contentDocument.body as any).scrollHeight = 200;
-            (window as any).innerWidth = 50;
+            (document.documentElement as any).clientWidth = 50;
 
             scroller.start(0);
             expect(iframe.style.height).to.equal("200px");
@@ -113,7 +113,7 @@ describe("ScrollingBookView", () => {
 
             document.body.scrollTop = 10;
             (document.body as any).scrollHeight = 200;
-            (window as any).innerHeight = 100;
+            (document.documentElement as any).clientHeight = 100;
 
             expect(scroller.atBottom()).to.equal(false);
 


### PR DESCRIPTION
On android and iOS 9 and lower, we disable zooming with a viewport meta tag. On iOS 10, that's disabled. Based on @winniequinn's suggestions, this makes the reader content work when zoomed in, but ignore swipes and taps. You have to zoom back out before turning the page. 

This will need a lot of cross-browser testing. So far, it seems to work well on iOS 10.3.1 but not as well on iOS 10.2.1, though still better than what happened before.