### PR TITLE
Config object arguments and configurable static file URLs for service worker to cache

### DIFF
--- a/examples/alice/index.html
+++ b/examples/alice/index.html
@@ -26,7 +26,17 @@
       var cacher = new ServiceWorkerCacher.default({
         store: store,
         manifestUrl: webpubManifestUrl,
-        serviceWorkerPath: "sw.js",
+        serviceWorkerUrl: new URL("sw.js", window.location.href),
+        staticFileUrls: [
+          new URL(window.location.href),
+          new URL("index.html", window.location.href),
+          new URL("main.css", window.location.href),
+          new URL("require.js", window.location.href),
+          new URL("fetch.js", window.location.href),
+          new URL("url-polyfill.js", window.location.href),
+          new URL("promise.js", window.location.href),
+          new URL("webpub-viewer.js", window.location.href)
+        ],
         fallbackBookCacheUrl: bookCacheUrl
       });
 

--- a/examples/alice/index.html
+++ b/examples/alice/index.html
@@ -22,17 +22,41 @@
       var webpubManifestUrl = new URL("manifest.json", window.location.href);
       var bookCacheUrl = new URL("appcache.html", window.location.href);
 
-      var store = new LocalStorageStore.default(webpubManifestUrl.href);
-      var cacher = new ServiceWorkerCacher.default(store, webpubManifestUrl, "sw.js", bookCacheUrl);
+      var store = new LocalStorageStore.default({ prefix: webpubManifestUrl.href });
+      var cacher = new ServiceWorkerCacher.default({
+        store: store,
+        manifestUrl: webpubManifestUrl,
+        serviceWorkerPath: "sw.js",
+        fallbackBookCacheUrl: bookCacheUrl
+      });
 
       var paginator = new ColumnsPaginatedBookView.default();
       var scroller = new ScrollingBookView.default();
-      var annotator = new LocalAnnotator.default(store);
+      var annotator = new LocalAnnotator.default({ store: store });
       var eventHandler = new EventHandler.default();
       var fontSizes = [ 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32 ];
       var defaultFontSize = 16;
-      BookSettings.default.create(store, [paginator, scroller], fontSizes, defaultFontSize).then(function (settings) {
-        IFrameNavigator.default.create(element, webpubManifestUrl, store, cacher, settings, annotator, paginator, scroller, eventHandler, new URL("http://example.com"), "Back");
+      BookSettings.default.create({
+        store: store,
+        bookViews: [paginator, scroller],
+        fontSizesInPixels: fontSizes,
+        defaultFontSizeInPixels: defaultFontSize
+      }).then(function (settings) {
+        IFrameNavigator.default.create({
+          element: element,
+          manifestUrl: webpubManifestUrl,
+          store: store,
+          cacher: cacher,
+          settings: settings,
+          annotator: annotator,
+          paginator: paginator,
+          scroller: scroller,
+          eventHandler: eventHandler,
+          upLink: {
+            url: new URL("http://example.com"),
+            label: "Back"
+          }
+        });
       });
     });
   </script>

--- a/examples/twenty/index.html
+++ b/examples/twenty/index.html
@@ -24,16 +24,35 @@
       var webpubManifestUrl = new URL("manifest.json", window.location.href);
       var bookCacheUrl = new URL("appcache.html", window.location.href);
 
-      var store = new LocalStorageStore.default(webpubManifestUrl.href);
-      var cacher = new ServiceWorkerCacher.default(store, webpubManifestUrl, "../sw.js", bookCacheUrl);
+      var store = new LocalStorageStore.default({ prefix: webpubManifestUrl.href });
+      var cacher = new ServiceWorkerCacher.default({
+        store: store,
+        manifestUrl: webpubManifestUrl,
+        serviceWorkerPath: "../sw.js",
+        fallbackBookCacheUrl: bookCacheUrl
+      });
 
       var paginator = new ColumnsPaginatedBookView.default();
       var scroller = new ScrollingBookView.default();
-      var annotator = new LocalAnnotator.default(store);
+      var annotator = new LocalAnnotator.default({ store: store });
       var fontSizes = [ 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32 ];
       var defaultFontSize = 16;
-      BookSettings.default.create(store, [paginator, scroller], fontSizes, defaultFontSize).then(function (settings) {
-        IFrameNavigator.default.create(element, webpubManifestUrl, store, cacher, settings, annotator, paginator, scroller);
+      BookSettings.default.create({
+        store: store,
+        bookViews: [paginator, scroller],
+        fontSizesInPixels: fontSizes,
+        defaultFontSizeInPixels: defaultFontSize
+      }).then(function (settings) {
+        IFrameNavigator.default.create({
+          element: element,
+          manifestUrl: webpubManifestUrl,
+          store: store,
+          cacher: cacher,
+          settings: settings,
+          annotator: annotator,
+          paginator: paginator,
+          scroller: scroller
+        });
       });
     });
   </script>

--- a/examples/twenty/index.html
+++ b/examples/twenty/index.html
@@ -28,7 +28,17 @@
       var cacher = new ServiceWorkerCacher.default({
         store: store,
         manifestUrl: webpubManifestUrl,
-        serviceWorkerPath: "../sw.js",
+        serviceWorkerUrl: new URL("../sw.js", window.location.href),
+        staticFileUrls: [
+          new URL(window.location.href),
+          new URL("index.html", window.location.href),
+          new URL("../main.css", window.location.href),
+          new URL("../require.js", window.location.href),
+          new URL("../fetch.js", window.location.href),
+          new URL("../url-polyfill.js", window.location.href),
+          new URL("../promise.js", window.location.href),
+          new URL("../webpub-viewer.js", window.location.href)
+        ],
         fallbackBookCacheUrl: bookCacheUrl
       });
 

--- a/src/ApplicationCacheCacher.ts
+++ b/src/ApplicationCacheCacher.ts
@@ -1,6 +1,10 @@
 import Cacher from "./Cacher";
 import { CacheStatus } from "./Cacher";
 
+export interface ApplicationCacheCacherConfig {
+    bookCacheUrl: URL
+}
+
 /** Class that caches files using the (deprecated) application cache API. 
     This is necessary until Service Worker support improves.
     
@@ -21,8 +25,8 @@ export default class ApplicationCacheCacher implements Cacher {
     private statusUpdateCallback: (status: CacheStatus) => void = () => {};
     private status: CacheStatus = CacheStatus.Uncached;
 
-    public constructor(bookCacheUrl: URL) {
-        this.bookCacheUrl = bookCacheUrl;
+    public constructor(config: ApplicationCacheCacherConfig) {
+        this.bookCacheUrl = config.bookCacheUrl;
     }
 
     public async enable(): Promise<void> {

--- a/src/BookSettings.ts
+++ b/src/BookSettings.ts
@@ -46,7 +46,7 @@ export interface BookSettingsConfig {
     /** Store to save the user's selections in. */
     store: Store,
 
-    /** Array of BookView options. */
+    /** Array of BookViews. */
     bookViews: BookView[],
 
     /** Array of font sizes in pixels sorted from smallest to largest. */

--- a/src/BookSettings.ts
+++ b/src/BookSettings.ts
@@ -42,6 +42,20 @@ const checkSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 45 32" pr
 </svg>
 `;
 
+export interface BookSettingsConfig {
+    /** Store to save the user's selections in. */
+    store: Store,
+
+    /** Array of BookView options. */
+    bookViews: BookView[],
+
+    /** Array of font sizes in pixels sorted from smallest to largest. */
+    fontSizesInPixels: number[],
+
+    /** Initial font size to use until the user makes a selection. */
+    defaultFontSizeInPixels?: number;
+}
+
 export default class BookSettings {
     private readonly store: Store;
     private readonly bookViews: BookView[];
@@ -60,14 +74,10 @@ export default class BookSettings {
     private static readonly SELECTED_VIEW_KEY = "settings-selected-view";
     private static readonly SELECTED_FONT_SIZE_KEY = "settings-selected-font-size";
 
-    /** @param store Store to save the user's selections in. */
-    /** @param bookViews Array of BookView options. */
-    /** @param fontSizesInPixels Array of font sizes in pixels sorted from smallest to largest. */
-    /** @param defaultFontSizeInPixels Initial font size to use until the user makes a selection. */
-    public static async create(store: Store, bookViews: BookView[], fontSizesInPixels: number[], defaultFontSizeInPixels?: number) {
-        const fontSizes = fontSizesInPixels.map(fontSize => fontSize + "px");
-        const settings = new this(store, bookViews, fontSizes);
-        await settings.initializeSelections(defaultFontSizeInPixels ? defaultFontSizeInPixels + "px" : undefined);
+    public static async create(config: BookSettingsConfig) {
+        const fontSizes = config.fontSizesInPixels.map(fontSize => fontSize + "px");
+        const settings = new this(config.store, config.bookViews, fontSizes);
+        await settings.initializeSelections(config.defaultFontSizeInPixels ? config.defaultFontSizeInPixels + "px" : undefined);
         return settings;
     }
 

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -121,6 +121,22 @@ interface ReadingPosition {
     position: number;
 }
 
+export interface IFrameNavigatorConfig {
+    element: HTMLElement;
+    manifestUrl: URL;
+    store: Store;
+    cacher: Cacher;
+    settings: BookSettings;
+    annotator?: Annotator;
+    paginator?: PaginatedBookView;
+    scroller?: ScrollingBookView;
+    eventHandler?: EventHandler;
+    upLink?:  {
+        url?: URL;
+        label?: string;
+    };
+}
+
 /** Class that shows webpub resources in an iframe, with navigation controls outside the iframe. */
 export default class IFrameNavigator implements Navigator {
     private manifestUrl: URL;
@@ -156,27 +172,15 @@ export default class IFrameNavigator implements Navigator {
     private newElementId: string | null;
     private isLoading: boolean;
 
-    public static async create(
-        element: HTMLElement,
-        manifestUrl: URL,
-        store: Store,
-        cacher: Cacher,
-        settings: BookSettings,
-        annotator: Annotator | null = null,
-        paginator: PaginatedBookView | null = null,
-        scroller: ScrollingBookView | null = null,
-        eventHandler: EventHandler | null = null,
-        upUrl: URL | null = null,
-        upLabel: string | null = "Back"
-        ) {
-
+    public static async create(config: IFrameNavigatorConfig) {
         const navigator = new this(
-            store, cacher, settings, annotator,
-            paginator, scroller, eventHandler,
-            upUrl, upLabel
+            config.store, config.cacher, config.settings, config.annotator || null,
+            config.paginator || null, config.scroller || null, config.eventHandler || null,
+            config.upLink ? config.upLink.url || null : null,
+            config.upLink ? config.upLink.label || null : null
         );
 
-        await navigator.start(element, manifestUrl);
+        await navigator.start(config.element, config.manifestUrl);
         return navigator;
     }
 

--- a/src/LocalAnnotator.ts
+++ b/src/LocalAnnotator.ts
@@ -1,13 +1,17 @@
 import Annotator from "./Annotator";
 import Store from "./Store";
 
+export interface LocalAnnotatorConfig {
+    store: Store;
+}
+
 /** Annotator that stores annotations locally, in the browser. */
 export default class LocalAnnotator implements Annotator {
     private readonly store: Store;
     private static readonly LAST_READING_POSITION = "last-reading-position";
 
-    public constructor(store: Store) {
-        this.store = store;
+    public constructor(config: LocalAnnotatorConfig) {
+        this.store = config.store;
     }
 
     public async getLastReadingPosition(): Promise<any> {

--- a/src/LocalStorageStore.ts
+++ b/src/LocalStorageStore.ts
@@ -1,19 +1,26 @@
 import Store from "./Store";
 import MemoryStore from "./MemoryStore";
 
+export interface LocalStorageStoreConfig {
+    /** String to prepend to keys in localStorage. If the same prefix is shared
+        across LocalStorageStores on the same domain, they will have the same
+        value for each key. */
+    prefix: string;
+}
+
 /** Class that stores key/value pairs in localStorage if possible
     but falls back to an in-memory store. */
 export default class LocalStorageStore implements Store {
     private fallbackStore: MemoryStore | null;
     private prefix: string;
     
-    public constructor(prefix: string) {
-        this.prefix = prefix;
+    public constructor(config: LocalStorageStoreConfig) {
+        this.prefix = config.prefix;
         try {
             // In some browsers (eg iOS Safari in private mode), 
             // localStorage exists but throws an exception when
             // you try to write to it.
-            const testKey = prefix + "-" + String(Math.random());
+            const testKey = config.prefix + "-" + String(Math.random());
             window.localStorage.setItem(testKey, "test");
             window.localStorage.removeItem(testKey);
             this.fallbackStore = null;

--- a/src/ServiceWorkerCacher.ts
+++ b/src/ServiceWorkerCacher.ts
@@ -4,6 +4,20 @@ import Store from "./Store";
 import Manifest from "./Manifest";
 import ApplicationCacheCacher from "./ApplicationCacheCacher";
 
+export interface ServiceWorkerCacherConfig {
+    /** Store to cache the manifest in. */
+    store: Store;
+
+    /** URL to the webpub's manifest. */
+    manifestUrl: URL;
+
+    /** Location of the service worker js file. Default: sw.js */
+    serviceWorkerPath?: string;
+
+    /** URL to give the ApplicationCacheCacher if service workers aren't supported. */
+    fallbackBookCacheUrl?: URL;
+}
+
 /** Class that caches responses using ServiceWorker's Cache API, and optionally
     falls back to the application cache if service workers aren't available. */
 export default class ServiceWorkerCacher implements Cacher {
@@ -16,19 +30,15 @@ export default class ServiceWorkerCacher implements Cacher {
     private statusUpdateCallback: (status: CacheStatus) => void = () => {};
 
     /** Create a ServiceWorkerCacher. */
-    /** @param store Store to cache the manifest in. */
-    /** @param manifestUrl URL to the webpub's manifest. */
-    /** @param serviceWorkerPath Location of the service worker js file. */
-    /** @param fallbackBookCacheUrl URL to give the ApplicationCacheCacher if service workers aren't supported. */
-    public constructor(store: Store, manifestUrl: URL, serviceWorkerPath: string = "sw.js", fallbackBookCacheUrl?: URL) {
-        this.serviceWorkerPath = serviceWorkerPath;
-        this.store = store;
-        this.manifestUrl = manifestUrl;
+    public constructor(config: ServiceWorkerCacherConfig) {
+        this.serviceWorkerPath = config.serviceWorkerPath || "sw.js";
+        this.store = config.store;
+        this.manifestUrl = config.manifestUrl;
 
         const protocol = window.location.protocol;
         this.areServiceWorkersSupported = !!navigator.serviceWorker && !!window.caches && (protocol === "https:");
-        if (!this.areServiceWorkersSupported && fallbackBookCacheUrl) {
-            this.fallbackCacher = new ApplicationCacheCacher(fallbackBookCacheUrl);
+        if (!this.areServiceWorkersSupported && config.fallbackBookCacheUrl) {
+            this.fallbackCacher = new ApplicationCacheCacher({ bookCacheUrl: config.fallbackBookCacheUrl });
         }
     }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,15 +7,29 @@ import BookSettings from "./BookSettings";
 import LocalAnnotator from "./LocalAnnotator";
 
 const app = async (element: HTMLElement, manifestUrl: URL): Promise<IFrameNavigator> => {
-    const bookStore = new LocalStorageStore(manifestUrl.href);
-    const cacher = new ServiceWorkerCacher(bookStore, manifestUrl);
-    const annotator = new LocalAnnotator(bookStore);
+    const bookStore = new LocalStorageStore({ prefix: manifestUrl.href });
+    const cacher = new ServiceWorkerCacher({ store: bookStore, manifestUrl });
+    const annotator = new LocalAnnotator({ store: bookStore });
     const paginator = new ColumnsPaginatedBookView();
     const scroller = new ScrollingBookView();
-    const settingsStore = new LocalStorageStore("all-books");
+    const settingsStore = new LocalStorageStore({ prefix: "all-books" });
     const fontSizes = [ 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32 ];
-    const settings = await BookSettings.create(settingsStore, [paginator, scroller], fontSizes, 16);
-    return await IFrameNavigator.create(element, manifestUrl, bookStore, cacher, settings, annotator, paginator, scroller);
+    const settings = await BookSettings.create({
+        store: settingsStore,
+        bookViews: [paginator, scroller],
+        fontSizesInPixels: fontSizes,
+        defaultFontSizeInPixels: 16
+    });
+    return await IFrameNavigator.create({
+        element,
+        manifestUrl,
+        store: bookStore,
+        cacher,
+        settings,
+        annotator,
+        paginator,
+        scroller
+    });
 };
 
 export default app;

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,21 +1,5 @@
 const CACHE_NAME = "webpub-viewer";
 
-const urlsToCache: any = [
-    "require.js",
-    "fetch.js",
-    "webpub-viewer.js",
-    "index.html",
-    "main.css"
-];
-
-self.addEventListener('install', event => {
-    const urlsCached = self.caches.open(CACHE_NAME).then((cache: any) => {
-        return cache.addAll(urlsToCache);
-    });
-    (event as any).waitUntil(urlsCached);
-    self.skipWaiting();
-});
-
 self.addEventListener('activate', () => {
     self.clients.claim();
 });

--- a/test/ApplicationCacheCacherTests.ts
+++ b/test/ApplicationCacheCacherTests.ts
@@ -11,7 +11,9 @@ describe("ApplicationCacheCacher", () => {
     let jsdomWindow: Window;
 
     beforeEach(() => {
-        cacher = new ApplicationCacheCacher(new URL("http://example.com/fallback.html"));
+        cacher = new ApplicationCacheCacher({
+            bookCacheUrl: new URL("http://example.com/fallback.html")
+        });
 
         jsdomWindow = jsdom.jsdom("", ({
             // This is useful for debugging errors in an iframe load event.
@@ -50,7 +52,9 @@ describe("ApplicationCacheCacher", () => {
                 }
             }
 
-            cacher = new MockCacher(new URL("http://example.com/fallback.html"));
+            cacher = new MockCacher({
+                bookCacheUrl: new URL("http://example.com/fallback.html")
+            });
 
             await cacher.enable();
             expect(updateStatus.callCount).to.equal(1);
@@ -87,7 +91,9 @@ describe("ApplicationCacheCacher", () => {
 
             const callback = stub();
 
-            const cacher: MockCacher = new MockCacher(new URL("http://example.com/fallback.html"));
+            const cacher: MockCacher = new MockCacher({
+                bookCacheUrl: new URL("http://example.com/fallback.html")
+            });
             cacher.onStatusUpdate(callback);
             expect(callback.callCount).to.equal(1);
             expect(callback.args[0][0]).to.equal(CacheStatus.Uncached);
@@ -141,7 +147,9 @@ describe("ApplicationCacheCacher", () => {
                 }
             }
 
-            const cacher: MockCacher = new MockCacher(new URL("http://example.com/fallback.html"));
+            const cacher: MockCacher = new MockCacher({
+                bookCacheUrl: new URL("http://example.com/fallback.html")
+            });
             expect(cacher.getStatus()).to.equal(CacheStatus.Uncached);
 
             (iframe.contentWindow as any).applicationCache = {};

--- a/test/BookSettingsTest.ts
+++ b/test/BookSettingsTest.ts
@@ -63,13 +63,21 @@ describe("BookSettings", () => {
         view2 = new MockBookView(2, "view2", "View 2");
 
         store = new MemoryStore();
-        settings = await BookSettings.create(store, [view1, view2], [12, 14, 16]);
+        settings = await BookSettings.create({
+            store,
+            bookViews: [view1, view2],
+            fontSizesInPixels: [12, 14, 16]
+        });
     });
 
     describe("#create", () => {
         it("obtains the selected view from the store", async () => {
             await store.set("settings-selected-view", view2.name);
-            settings = await BookSettings.create(store, [view1, view2], []);
+            settings = await BookSettings.create({
+                store,
+                bookViews: [view1, view2],
+                fontSizesInPixels: []
+            });
             expect(settings.getSelectedView()).to.equal(view2);
         });
 
@@ -79,33 +87,60 @@ describe("BookSettings", () => {
 
         it("obtains the selected font size from the store", async () => {
             await store.set("settings-selected-font-size", "18px");
-            settings = await BookSettings.create(store, [view1, view2], [12, 14, 16, 18]);
+            settings = await BookSettings.create({
+                store,
+                bookViews: [view1, view2],
+                fontSizesInPixels: [12, 14, 16, 18]
+            });
             expect(settings.getSelectedFontSize()).to.equal("18px");
         });
 
         it("sets the selected font size to the default if the selected font size in the store isn't one of the options", async () => {
             await store.set("settings-selected-font-size", "12345px");
-            settings = await BookSettings.create(store, [view1, view2], [12, 14, 16, 18], 18);
+            settings = await BookSettings.create({
+                store,
+                bookViews: [view1, view2],
+                fontSizesInPixels: [12, 14, 16, 18],
+                defaultFontSizeInPixels: 18
+            });
             expect(settings.getSelectedFontSize()).to.equal("18px");
         });
 
         it("sets the selected font size to the default if there's no selected font size in the store", async () => {
-            settings = await BookSettings.create(store, [view1, view2], [14, 16], 14);
+            settings = await BookSettings.create({
+                store,
+                bookViews: [view1, view2],
+                fontSizesInPixels: [14, 16],
+                defaultFontSizeInPixels: 14
+            });
             expect(settings.getSelectedFontSize()).to.equal("14px");
         });
 
         it("sets the selected font size to the middle font size if the default isn't one of the options", async () => {
-            settings = await BookSettings.create(store, [view1, view2], [14, 16], 12345);
+            settings = await BookSettings.create({
+                store,
+                bookViews: [view1, view2],
+                fontSizesInPixels: [14, 16],
+                defaultFontSizeInPixels: 12345
+            });
             expect(settings.getSelectedFontSize()).to.equal("16px");
         });
 
         it("sets the selected font size to the middle font size (rounded up) if there's no default and no selected font size in the store", async () => {
             expect(settings.getSelectedFontSize()).to.equal("14px");
 
-            settings = await BookSettings.create(store, [view1, view2], [12, 14]);
+            settings = await BookSettings.create({
+                store,
+                bookViews: [view1, view2],
+                fontSizesInPixels: [12, 14]
+            });
             expect(settings.getSelectedFontSize()).to.equal("14px");
 
-            settings = await BookSettings.create(store, [view1, view2], [10, 12, 14, 16]);
+            settings = await BookSettings.create({
+                store,
+                bookViews: [view1, view2],
+                fontSizesInPixels: [10, 12, 14, 16]
+            });
             expect(settings.getSelectedFontSize()).to.equal("14px");
         });
     });
@@ -124,14 +159,22 @@ describe("BookSettings", () => {
 
             // If there's no views or only 1 view, views don't show up in the settings.
 
-            settings = await BookSettings.create(store, [view1], [12]);
+            settings = await BookSettings.create({
+                store,
+                bookViews: [view1],
+                fontSizesInPixels: [12]
+            });
             settings.renderControls(element);
             view1Button = element.querySelector("button[class='view1 active']") as HTMLButtonElement;
             expect(view1Button).to.be.null;
             view2Button = element.querySelector("button[class=view2]") as HTMLButtonElement;
             expect(view2Button).to.be.null;
 
-            settings = await BookSettings.create(store, [], [12]);
+            settings = await BookSettings.create({
+                store,
+                bookViews: [],
+                fontSizesInPixels: [12]
+            });
             settings.renderControls(element);
             view1Button = element.querySelector("button[class='view1 active']") as HTMLButtonElement;
             expect(view1Button).to.be.null;
@@ -203,7 +246,11 @@ describe("BookSettings", () => {
 
             // If there's no font size or only one font size, font size controls don't show up in settings.
 
-            settings = await BookSettings.create(store, [view1], [12]);
+            settings = await BookSettings.create({
+                store,
+                bookViews: [view1],
+                fontSizesInPixels: [12]
+            });
             settings.renderControls(element);
             decreaseButton = element.querySelector("button[class='decrease']") as HTMLButtonElement;
             expect(decreaseButton).to.be.null;
@@ -212,7 +259,11 @@ describe("BookSettings", () => {
             label = element.querySelector(".font-size-label") as HTMLLIElement;
             expect(label).to.be.null;
 
-            settings = await BookSettings.create(store, [view1], []);
+            settings = await BookSettings.create({
+                store,
+                bookViews: [view1],
+                fontSizesInPixels: []
+            });
             settings.renderControls(element);
             decreaseButton = element.querySelector("button[class='decrease']") as HTMLButtonElement;
             expect(decreaseButton).to.be.null;

--- a/test/IFrameNavigatorTests.ts
+++ b/test/IFrameNavigatorTests.ts
@@ -226,7 +226,11 @@ describe("IFrameNavigator", () => {
         getSelectedView = stub().returns(paginator);
         getSelectedFontSize = stub().returns("14px");
         getOfflineStatusElement = stub().returns(offlineStatusElement);
-        settings = await MockSettings.create(store, [paginator, scroller], [14, 16]);
+        settings = await MockSettings.create({
+            store,
+            bookViews: [paginator, scroller],
+            fontSizesInPixels: [14, 16]
+        });
 
         setupEvents = stub();
         eventHandler = new MockEventHandler();
@@ -248,7 +252,17 @@ describe("IFrameNavigator", () => {
         // The element must be in a document for iframe load events to work.
         window.document.body.appendChild(element);
         (window as any).innerWidth = 1024;
-        navigator = await IFrameNavigator.create(element, new URL("http://example.com/manifest.json"), store, cacher, settings, annotator, paginator, scroller, eventHandler);
+        navigator = await IFrameNavigator.create({
+            element,
+            manifestUrl: new URL("http://example.com/manifest.json"),
+            store,
+            cacher,
+            settings,
+            annotator,
+            paginator,
+            scroller,
+            eventHandler
+        });
     });
 
     describe("#start", () => {
@@ -485,7 +499,21 @@ describe("IFrameNavigator", () => {
             // The up link isn't shown if it's not configured.
             expect(noUpLink).not.to.be.ok;
 
-            navigator = await IFrameNavigator.create(element, new URL("http://example.com/manifest.json"), store, cacher, settings, annotator, paginator, scroller, eventHandler, new URL("http://up.com"), "Up Text");
+            navigator = await IFrameNavigator.create({
+                element,
+                manifestUrl: new URL("http://example.com/manifest.json"),
+                store,
+                cacher,
+                settings,
+                annotator,
+                paginator,
+                scroller,
+                eventHandler,
+                upLink: {
+                    url: new URL("http://up.com"),
+                    label: "Up Text"
+                }
+            });
             
             const upLink = element.querySelector("a[rel=up]") as HTMLAnchorElement;
             expect(upLink).to.be.ok;
@@ -896,7 +924,17 @@ describe("IFrameNavigator", () => {
             }, new URL("http://example.com/manifest.json"));
             store.set("manifest", JSON.stringify(manifest));
 
-            navigator = await IFrameNavigator.create(element, new URL("http://example.com/manifest.json"), store, cacher, settings, annotator, paginator, scroller, eventHandler);
+            navigator = await IFrameNavigator.create({
+                element,
+                manifestUrl: new URL("http://example.com/manifest.json"),
+                store,
+                cacher,
+                settings,
+                annotator,
+                paginator,
+                scroller,
+                eventHandler
+            });
             const toc = element.querySelector(".contents-view") as HTMLDivElement;
             expect(toc.parentElement.style.display).to.equal("none");
         });
@@ -1371,7 +1409,17 @@ describe("IFrameNavigator", () => {
             expect(scrollingSuggestion.style.display).not.to.equal("none");
 
             getSelectedView.returns(scroller);            
-            navigator = await IFrameNavigator.create(element, new URL("http://example.com/manifest.json"), store, cacher, settings, annotator, paginator, scroller, eventHandler);
+            navigator = await IFrameNavigator.create({
+                element,
+                manifestUrl: new URL("http://example.com/manifest.json"),
+                store,
+                cacher,
+                settings,
+                annotator,
+                paginator,
+                scroller,
+                eventHandler
+            });
             scrollingSuggestion = element.querySelector(".scrolling-suggestion") as HTMLAnchorElement;
             
             expect(scrollingSuggestion.style.display).to.equal("none");

--- a/test/IFrameNavigatorTests.ts
+++ b/test/IFrameNavigatorTests.ts
@@ -876,9 +876,9 @@ describe("IFrameNavigator", () => {
             iframe.src = "http://example.com/item-1.html";
             await pause();
             click(next);
-            await pause(250);
+            await pause(200);
             expect(loading.style.display).not.to.equal("none");
-            await pause(100);
+            await pause(150);
             expect(loading.style.display).to.equal("none");
         });
 

--- a/test/LocalAnnotatorTests.ts
+++ b/test/LocalAnnotatorTests.ts
@@ -9,7 +9,7 @@ describe("LocalAnnotator", () => {
 
     beforeEach(() => {
         store = new MemoryStore();
-        annotator = new LocalAnnotator(store);
+        annotator = new LocalAnnotator({ store });
     });
 
     describe("#getLastReadingPosition", async () => {

--- a/test/LocalStorageStoreTests.ts
+++ b/test/LocalStorageStoreTests.ts
@@ -22,7 +22,7 @@ describe("LocalStorageStore", () => {
     });
 
     it("falls back to memory store if localStorage is not available", async () => {
-        store = new LocalStorageStore("prefix");
+        store = new LocalStorageStore({ prefix: "prefix" });
 
         // #get returns null for a value that has not been set.
         let value = await store.get("key");
@@ -36,7 +36,7 @@ describe("LocalStorageStore", () => {
     it("uses localStorage if available, and adds manifest url to keys", async () => {
         mockLocalStorageAPI();
 
-        store = new LocalStorageStore("prefix");
+        store = new LocalStorageStore({ prefix: "prefix" });
 
         getItem.returns(null);
 

--- a/test/ServiceWorkerCacherTests.ts
+++ b/test/ServiceWorkerCacherTests.ts
@@ -92,17 +92,17 @@ describe('ServiceWorkerCacher', () => {
             });
             await cacher.enable();
             expect(register.callCount).to.equal(1);
-            expect(register.args[0][0]).to.equal("sw.js");
+            expect(register.args[0][0]).to.equal("https://example.com/sw.js");
 
             cacher = new ServiceWorkerCacher({
                 store,
                 manifestUrl: new URL("https://example.com/manifest.json"),
-                serviceWorkerPath: "../../../sw.js",
+                serviceWorkerUrl: new URL("../../../sw.js", "https://example.com/1/2/3/4/"),
                 fallbackBookCacheUrl: new URL("https://example.com/fallback.html")
             });
             await cacher.enable();
             expect(register.callCount).to.equal(2);
-            expect(register.args[1][0]).to.equal("../../../sw.js");
+            expect(register.args[1][0]).to.equal("https://example.com/1/sw.js");
         });
 
         it("shouldn't cache anything if it has already successfully cached everything", async () => {
@@ -148,7 +148,11 @@ describe('ServiceWorkerCacher', () => {
             await store.set("manifest", JSON.stringify(manifest));
             const cacher = new ServiceWorkerCacher({
                 store,
-                manifestUrl: new URL("https://example.com/manifest.json")
+                manifestUrl: new URL("https://example.com/manifest.json"),
+                staticFileUrls: [
+                    new URL("static-1.html", "https://example.com"),
+                    new URL("static-2.html", "https://example.com")
+                ]
             });
             await cacher.enable();
             let urlsThatWereCached: Array<string> = [];
@@ -159,7 +163,8 @@ describe('ServiceWorkerCacher', () => {
                 urlsThatWereCached = urlsThatWereCached.concat(urls);
             });
             expect(urlsThatWereCached).to.contain("https://example.com/manifest.json");
-            expect(urlsThatWereCached).to.contain("https://example.com/index.html");
+            expect(urlsThatWereCached).to.contain("https://example.com/static-1.html");
+            expect(urlsThatWereCached).to.contain("https://example.com/static-2.html");
             expect(urlsThatWereCached).to.contain("https://example.com/spine-item-1.html");
             expect(urlsThatWereCached).to.contain("https://example.com/spine-item-2.html");
             expect(urlsThatWereCached).to.contain("https://example.com/resource-1.html");

--- a/test/ServiceWorkerCacherTests.ts
+++ b/test/ServiceWorkerCacherTests.ts
@@ -59,7 +59,10 @@ describe('ServiceWorkerCacher', () => {
         it("should do nothing if the Cache API is not supported and there's no fallback URL", async () => {
             (window as any).caches = null;
 
-            const cacher = new ServiceWorkerCacher(store, new URL("https://example.com/manifest.json"));
+            const cacher = new ServiceWorkerCacher({
+                store,
+                manifestUrl: new URL("https://example.com/manifest.json")
+            });
             await cacher.enable();
             expect(register.callCount).to.equal(0);
         });
@@ -69,7 +72,11 @@ describe('ServiceWorkerCacher', () => {
 
             const appCacheEnableStub = stub(ApplicationCacheCacher.prototype, "enable");
 
-            const cacher = new ServiceWorkerCacher(store, new URL("https://example.com/manifest.json"), "sw.js", new URL("https://example.com/fallback.html"));
+            const cacher = new ServiceWorkerCacher({
+                store,
+                manifestUrl: new URL("https://example.com/manifest.json"),
+                fallbackBookCacheUrl: new URL("https://example.com/fallback.html")
+            });
             await cacher.enable();
             expect(register.callCount).to.equal(0);
             expect(appCacheEnableStub.callCount).to.equal(1);
@@ -79,12 +86,20 @@ describe('ServiceWorkerCacher', () => {
 
         it("should register the service worker", async () => {
             mockCacheAPI("i'm in the cache");
-            let cacher = new ServiceWorkerCacher(store, new URL("https://example.com/manifest.json"));
+            let cacher = new ServiceWorkerCacher({
+                store,
+                manifestUrl: new URL("https://example.com/manifest.json")
+            });
             await cacher.enable();
             expect(register.callCount).to.equal(1);
             expect(register.args[0][0]).to.equal("sw.js");
 
-            cacher = new ServiceWorkerCacher(store, new URL("https://example.com/manifest.json"), "../../../sw.js", new URL("https://example.com/fallback.html"));
+            cacher = new ServiceWorkerCacher({
+                store,
+                manifestUrl: new URL("https://example.com/manifest.json"),
+                serviceWorkerPath: "../../../sw.js",
+                fallbackBookCacheUrl: new URL("https://example.com/fallback.html")
+            });
             await cacher.enable();
             expect(register.callCount).to.equal(2);
             expect(register.args[1][0]).to.equal("../../../sw.js");
@@ -100,7 +115,10 @@ describe('ServiceWorkerCacher', () => {
                 }
             }
 
-            const cacher = new MockCacher(store, new URL("https://example.com/manifest.json"));
+            const cacher = new MockCacher({
+                store,
+                manifestUrl: new URL("https://example.com/manifest.json")
+            });
             cacher.setStatus(CacheStatus.Downloaded);
             await cacher.enable();
             // The manifest cache was not opened.
@@ -128,7 +146,10 @@ describe('ServiceWorkerCacher', () => {
             }, new URL("https://example.com/manifest.json"));
 
             await store.set("manifest", JSON.stringify(manifest));
-            const cacher = new ServiceWorkerCacher(store, new URL("https://example.com/manifest.json"));
+            const cacher = new ServiceWorkerCacher({
+                store,
+                manifestUrl: new URL("https://example.com/manifest.json")
+            });
             await cacher.enable();
             let urlsThatWereCached: Array<string> = [];
             // Go through each call to addAll and aggregate the cached URLs.
@@ -152,7 +173,11 @@ describe('ServiceWorkerCacher', () => {
 
             const appCacheOnStatusUpdateStub = stub(ApplicationCacheCacher.prototype, "onStatusUpdate");
 
-            const cacher = new ServiceWorkerCacher(store, new URL("https://example.com/manifest.json"), "sw.js", new URL("https://example.com/fallback.html"));
+            const cacher = new ServiceWorkerCacher({
+                store,
+                manifestUrl: new URL("https://example.com/manifest.json"),
+                fallbackBookCacheUrl: new URL("https://example.com/fallback.html")
+            });
             const callback = stub();
             cacher.onStatusUpdate(callback);
             expect(appCacheOnStatusUpdateStub.callCount).to.equal(1);
@@ -176,7 +201,10 @@ describe('ServiceWorkerCacher', () => {
 
             await store.set("manifest", JSON.stringify(manifest));
 
-            const cacher = new ServiceWorkerCacher(store, new URL("https://example.com/manifest.json"));
+            const cacher = new ServiceWorkerCacher({
+                store,
+                manifestUrl: new URL("https://example.com/manifest.json")
+            });
 
             const callback = stub();
             cacher.onStatusUpdate(callback);
@@ -196,7 +224,10 @@ describe('ServiceWorkerCacher', () => {
         it("should provide status updates when there's an error", async () => {
             mockCacheAPI("i'm in the cache");
             open.returns(new Promise<void>((_, reject) => reject()));
-            const cacher = new ServiceWorkerCacher(store, new URL("https://example.com/manifest.json"));
+            const cacher = new ServiceWorkerCacher({
+                store,
+                manifestUrl: new URL("https://example.com/manifest.json")
+            });
 
             const callback = stub();
             cacher.onStatusUpdate(callback);
@@ -230,7 +261,10 @@ describe('ServiceWorkerCacher', () => {
 
             await store.set("manifest", JSON.stringify(manifest));
 
-            const cacher = new ServiceWorkerCacher(store, new URL("https://example.com/manifest.json"));
+            const cacher = new ServiceWorkerCacher({
+                store,
+                manifestUrl: new URL("https://example.com/manifest.json")
+            });
 
             expect(cacher.getStatus()).to.equal(CacheStatus.Uncached);
 
@@ -244,7 +278,10 @@ describe('ServiceWorkerCacher', () => {
         it("should provide status updates when there's an error", async () => {
             mockCacheAPI("i'm in the cache");
             open.returns(new Promise<void>((_, reject) => reject()));
-            const cacher = new ServiceWorkerCacher(store, new URL("https://example.com/manifest.json"));
+            const cacher = new ServiceWorkerCacher({
+                store,
+                manifestUrl: new URL("https://example.com/manifest.json")
+            });
 
             expect(cacher.getStatus()).to.equal(CacheStatus.Uncached);
 


### PR DESCRIPTION
This fixes #54 
This fixes #104 

When I started minifying JS and CSS, I broke the service worker caching because I had hard-coded file names to be cached on install in the service worker itself. I moved all of those to an argument that gets passed into the service worker cacher instead so they can be configurable without having to modify the built service worker file. Since I was adding an argument I decided to go ahead and do #54 as well. 

I don't actually want to merge this into add-xicon-#94, but it's easier to review that way. I'll change this to go to master once that branch is done. 