### PR TITLE
Make images fit the screen width in scrolling mode.

### DIFF
--- a/src/ColumnsPaginatedBookView.ts
+++ b/src/ColumnsPaginatedBookView.ts
@@ -125,6 +125,18 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
         this.bookElement.contentDocument.documentElement.style.height = "";
         this.bookElement.style.height = "";
         this.bookElement.style.width = "";
+
+        const images = body.querySelectorAll("img");
+        for (const image of images) {
+            image.style.maxWidth = "";
+            image.style.maxHeight = "";
+
+            // Without this, an image at the end of a resource can end up
+            // with an extra empty column after it.
+            image.style.display = "";
+            image.style.marginLeft = "";
+            image.style.marginRight = "";
+        }
     }
 
     /** Returns the total width of the columns that are currently

--- a/src/ColumnsPaginatedBookView.ts
+++ b/src/ColumnsPaginatedBookView.ts
@@ -130,9 +130,6 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
         for (const image of images) {
             image.style.maxWidth = "";
             image.style.maxHeight = "";
-
-            // Without this, an image at the end of a resource can end up
-            // with an extra empty column after it.
             image.style.display = "";
             image.style.marginLeft = "";
             image.style.marginRight = "";

--- a/src/ScrollingBookView.ts
+++ b/src/ScrollingBookView.ts
@@ -17,13 +17,19 @@ export default class ScrollingBookView implements BookView {
 
         const body = HTMLUtilities.findRequiredElement(this.bookElement.contentDocument, "body") as HTMLBodyElement;
 
-        body.style.width = (BrowserUtilities.getWidth() - this.sideMargin * 2) + "px";
+        const width = (BrowserUtilities.getWidth() - this.sideMargin * 2) + "px";
+        body.style.width = width;
         body.style.marginLeft = this.sideMargin + "px";
         body.style.marginRight = this.sideMargin + "px";
 
         const minHeight = this.height;
         const bodyHeight = body.scrollHeight;
         this.bookElement.style.height = Math.max(minHeight, bodyHeight) + "px";
+
+        const images = Array.prototype.slice.call(body.querySelectorAll("img"));
+        for (const image of images) {
+            image.style.maxWidth = width;
+        }
     }
 
     public start(position: number): void {
@@ -38,6 +44,11 @@ export default class ScrollingBookView implements BookView {
         body.style.width = "";
         body.style.marginLeft = "";
         body.style.marginRight = "";
+
+        const images = Array.prototype.slice.call(body.querySelectorAll("img"));
+        for (const image of images) {
+            image.style.maxWidth = "";
+        }
     }
 
     public getCurrentPosition(): number {

--- a/test/ScrollingBookViewTests.ts
+++ b/test/ScrollingBookViewTests.ts
@@ -54,6 +54,19 @@ describe("ScrollingBookView", () => {
             expect(iframe.contentDocument.body.style.marginLeft).to.equal("11px");
             expect(iframe.contentDocument.body.style.marginRight).to.equal("11px");
         });
+
+        it("should set max width and but not height on image in iframe", () => {
+            scroller.sideMargin = 11;
+            scroller.height = 70;
+            (document.documentElement as any).clientWidth = 50;
+            const body = iframe.contentDocument.body;
+            const image  = window.document.createElement("img");
+            body.appendChild(image);
+
+            scroller.start(0);
+            expect(image.style.maxWidth).to.equal("28px");
+            expect(image.style.maxHeight).not.to.be.ok;
+        });
     });
 
     describe("#stop", () => {


### PR DESCRIPTION
This fixes #119.

I added a max-width to all images in scrolling view. I noticed the columns view wasn't removing the image styling when it stopped, so I did that too.