### PR TITLE
Account for parent margins when setting max image height, and ensure that right column width is never negative.

### DIFF
--- a/src/ColumnsPaginatedBookView.ts
+++ b/src/ColumnsPaginatedBookView.ts
@@ -63,7 +63,7 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
         // all the vendor-prefixed attributes.
         const body = HTMLUtilities.findRequiredElement(this.bookElement.contentDocument, "body") as any;
 
-        const width = (BrowserUtilities.getWidth() - this.sideMargin * 2) + "px"
+        const width = (BrowserUtilities.getWidth() - this.sideMargin * 2) + "px";
         body.style.columnWidth = width;
         body.style.WebkitColumnWidth = width;
         body.style.MozColumnWidth = width;
@@ -83,7 +83,21 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
         const images = body.querySelectorAll("img");
         for (const image of images) {
             image.style.maxWidth = width;
-            image.style.maxHeight = this.height + "px";
+
+            // Determine how much vertical space there is for the image.
+            let nextElement = image;
+            let totalMargins = 0;
+            while (nextElement !== body) {
+                const computedStyle = window.getComputedStyle(nextElement);
+                if (computedStyle.marginTop) {
+                    totalMargins += parseInt(computedStyle.marginTop.slice(0, -2), 10)
+                }
+                if (computedStyle.marginBottom) {
+                    totalMargins += parseInt(computedStyle.marginBottom.slice(0, -2), 10)
+                }
+                nextElement = nextElement.parentElement;
+            }
+            image.style.maxHeight = (this.height - totalMargins) + "px";
 
             // Without this, an image at the end of a resource can end up
             // with an extra empty column after it.
@@ -167,7 +181,7 @@ export default class ColumnsPaginatedBookView implements PaginatedBookView {
             // scrollWidth doesn't change when some columns
             // are off to the left, so we need to subtract them.
             const leftWidth = this.getLeftColumnsWidth();
-            rightWidth = rightWidth - leftWidth;
+            rightWidth = Math.max(0, rightWidth - leftWidth);
         }
         
         if (rightWidth === this.sideMargin) {

--- a/test/ColumnsPaginatedBookViewTests.ts
+++ b/test/ColumnsPaginatedBookViewTests.ts
@@ -68,6 +68,26 @@ describe("ColumnsPaginatedBookView", () => {
             expect(image.style.maxHeight).to.equal("200px");
         });
 
+        it("should set max height on image using parent element margins", () => {
+            const body = iframe.contentDocument.body;
+
+            const parent1 = window.document.createElement("p");
+            parent1.style.marginTop = "5px";
+
+            const parent2 = window.document.createElement("span");
+            parent2.style.marginTop = "6px";
+            parent2.style.marginBottom = "3px";
+
+            const image  = window.document.createElement("img");
+
+            parent2.appendChild(image);
+            parent1.appendChild(parent2);
+            body.appendChild(parent1);
+
+            paginator.start(0);
+            expect(image.style.maxHeight).to.equal("186px");
+        });
+
         it("should set initial position to first or last page", () => {
             // Set read-only properties.
             (iframe.contentDocument.body as any).offsetWidth = 100;


### PR DESCRIPTION
Fixes #120 
Fixes #122