### PR TITLE
Removed padding to fix #132

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nypl-simplified-webpub-viewer",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "NYPL",
   "description": "A viewer application for web publications.",
   "repository": "https://github.com/NYPL-Simplified/webpub-viewer.git",

--- a/src/styles/sass/main.scss
+++ b/src/styles/sass/main.scss
@@ -151,7 +151,6 @@ a {
           display: inline-block;
           margin-top: 0.175rem;
           margin-left: 0.625rem;
-          padding: 0.5rem 0.35rem 0.3rem;
 
           a[rel="up"] {
             display: inline-block;


### PR DESCRIPTION
This fixes #132 

Without a back button, this padding makes the contents button overlap the bottom border of the top links.

When the back button is there, taking it out moves the buttons slightly, but I think everything still looks fine without the padding.