### PR TITLE
JSON `spine` now `readingOrder` in Readium webpub manifest

### DIFF
--- a/src/Manifest.ts
+++ b/src/Manifest.ts
@@ -61,7 +61,7 @@ export default class Manifest {
     public constructor(manifestJSON: any, manifestUrl: URL) {
         this.metadata = manifestJSON.metadata || {};
         this.links = manifestJSON.links || [];
-        this.spine = manifestJSON.spine || [];
+        this.spine = (manifestJSON.readingOrder || manifestJSON.spine) || [];
         this.resources = manifestJSON.resources || [];
         this.toc = manifestJSON.toc || [];
         this.manifestUrl = manifestUrl;

--- a/src/ServiceWorkerCacher.ts
+++ b/src/ServiceWorkerCacher.ts
@@ -104,7 +104,8 @@ export default class ServiceWorkerCacher implements Cacher {
 
     private async cacheSpine(manifest: Manifest, manifestUrl: URL): Promise<void> {
         const urls: Array<string> = [];
-        for (const resource of manifest.spine) {
+        const spn = manifest.readingOrder || manifest.spine;
+        for (const resource of spn) {
             if (resource.href) {
                 urls.push(resource.href);
             }

--- a/src/ServiceWorkerCacher.ts
+++ b/src/ServiceWorkerCacher.ts
@@ -104,8 +104,7 @@ export default class ServiceWorkerCacher implements Cacher {
 
     private async cacheSpine(manifest: Manifest, manifestUrl: URL): Promise<void> {
         const urls: Array<string> = [];
-        const spn = manifest.readingOrder || manifest.spine;
-        for (const resource of spn) {
+        for (const resource of manifest.spine) {
             if (resource.href) {
                 urls.push(resource.href);
             }


### PR DESCRIPTION
This code fix preserves `spine` for backward-compatibility.