### PR TITLE
Allow custom library icons to be displayed in nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ========
 ## [0.1.3]
-- Allow custom `libraryIcon` URL to be used in wepub-viewer uplink (navigation).
+- Require URL, label, ariaLabel and libraryIcon URL(new) to be passed into wepub-viewer upLink for navigation.  
+- Wrap upLabel in URL.
 
 ## [0.1.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ========
+## [0.1.3]
+- Allow custom `libraryIcon` URL to be used in wepub-viewer uplink (navigation).
 
 ## [0.1.2]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "library-simplified-webpub-viewer",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "NYPL Digital",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/NYPL-simplified/webpub-viewer",

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -37,9 +37,10 @@ const upLinkImage = (label: string, image?: string) => {
 const upLinkTemplate = (
   label: string,
   ariaLabel: string,
-  libraryIcon: string
+  libraryIcon: string,
+  url: string
 ) => `
-  <a rel="up" aria-label="${ariaLabel}" tabindex="0">
+  <a href="${url}" rel="up" aria-label="${ariaLabel}" tabindex="0">
   ${upLinkImage(label, libraryIcon)}
     <span class="setting-text up">${label}</span>
   </a>
@@ -791,10 +792,16 @@ export default class IFrameNavigator implements Navigator {
       }
 
       if (this.upLinkConfig && this.upLinkConfig.url) {
+        const upUrl = this.upLinkConfig.url.href;
         const upLabel = this.upLinkConfig.label || "";
         const upAriaLabel = this.upLinkConfig.ariaLabel || upLabel;
         const upLibraryIcon = this.upLinkConfig.libraryIcon?.href || "";
-        const upHTML = upLinkTemplate(upLabel, upAriaLabel, upLibraryIcon);
+        const upHTML = upLinkTemplate(
+          upLabel,
+          upAriaLabel,
+          upLibraryIcon,
+          upUrl
+        );
         const upParent: HTMLLIElement = document.createElement("li");
         upParent.classList.add("uplink-wrapper");
         upParent.innerHTML = upHTML;

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -147,10 +147,10 @@ interface ReadingPosition {
 }
 
 export interface UpLinkConfig {
-  url?: URL;
-  label?: string;
-  ariaLabel?: string;
-  libraryIcon?: URL;
+  url: URL;
+  label: string;
+  ariaLabel: string;
+  libraryIcon: URL;
 }
 
 export interface IFrameNavigatorConfig {

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -37,8 +37,8 @@ const upLinkImage = (label: string, image?: string) => {
 const upLinkTemplate = (
   label: string,
   ariaLabel: string,
-  libraryIcon: string,
-  url: string
+  url: string,
+  libraryIcon?: string
 ) => `
   <a href="${url}" rel="up" aria-label="${ariaLabel}" tabindex="0">
   ${upLinkImage(label, libraryIcon)}
@@ -151,7 +151,7 @@ export interface UpLinkConfig {
   url: URL;
   label: string;
   ariaLabel: string;
-  libraryIcon: URL;
+  libraryIcon?: URL;
 }
 
 export interface IFrameNavigatorConfig {
@@ -799,8 +799,8 @@ export default class IFrameNavigator implements Navigator {
         const upHTML = upLinkTemplate(
           upLabel,
           upAriaLabel,
-          upLibraryIcon,
-          upUrl
+          upUrl,
+          upLibraryIcon
         );
         const upParent: HTMLLIElement = document.createElement("li");
         upParent.classList.add("uplink-wrapper");

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -24,12 +24,19 @@ const epubReadingSystemObject: EpubReadingSystemObject = {
 
 const epubReadingSystem = Object.freeze(epubReadingSystemObject);
 
-const upLinkTemplate = (label: string, ariaLabel: string) => `
+const upLinkImage = (label: string, image?: string) => {
+  if (image) {
+    return `<img src="${image}" width="${IconLib.WIDTH_ATTR}" height="${IconLib.HEIGHT_ATTR}" viewBox="${IconLib.VIEWBOX_ATTR}" title="${label}" preserveAspectRatio = "xMidYMid meet" role = "img" class="icon" >`;
+  } else {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width = "${IconLib.WIDTH_ATTR}" height = "${IconLib.HEIGHT_ATTR}" viewBox = "${IconLib.VIEWBOX_ATTR}"aria-labelledby="up-label" preserveAspectRatio = "xMidYMid meet" role = "img" class="icon" >
+      <title id="up-label">${label} </title> 
+    ${IconLib.icons.home}
+    </svg>`;
+  }
+};
+const upLinkTemplate = (label: string, ariaLabel: string, libraryIcon: string) => `
   <a rel="up" aria-label="${ariaLabel}" tabindex="0">
-    <svg xmlns="http://www.w3.org/2000/svg" width="${IconLib.WIDTH_ATTR}" height="${IconLib.HEIGHT_ATTR}" viewBox="${IconLib.VIEWBOX_ATTR}" aria-labelledby="up-label" preserveAspectRatio="xMidYMid meet" role="img" class="icon">
-      <title id="up-label">${label}</title>
-      ${IconLib.icons.home}
-    </svg>
+  ${upLinkImage(label, libraryIcon)}
     <span class="setting-text up">${label}</span>
   </a>
 `;
@@ -139,6 +146,7 @@ export interface UpLinkConfig {
   url?: URL;
   label?: string;
   ariaLabel?: string;
+  libraryIcon?: string;
 }
 
 export interface IFrameNavigatorConfig {
@@ -781,7 +789,8 @@ export default class IFrameNavigator implements Navigator {
       if (this.upLinkConfig && this.upLinkConfig.url) {
         const upLabel = this.upLinkConfig.label || "";
         const upAriaLabel = this.upLinkConfig.ariaLabel || upLabel;
-        const upHTML = upLinkTemplate(upLabel, upAriaLabel);
+        const upLibraryIcon = this.upLinkConfig.libraryIcon || "";
+        const upHTML = upLinkTemplate(upLabel, upAriaLabel, upLibraryIcon);
         const upParent: HTMLLIElement = document.createElement("li");
         upParent.classList.add("uplink-wrapper");
         upParent.innerHTML = upHTML;

--- a/src/IFrameNavigator.ts
+++ b/src/IFrameNavigator.ts
@@ -34,7 +34,11 @@ const upLinkImage = (label: string, image?: string) => {
     </svg>`;
   }
 };
-const upLinkTemplate = (label: string, ariaLabel: string, libraryIcon: string) => `
+const upLinkTemplate = (
+  label: string,
+  ariaLabel: string,
+  libraryIcon: string
+) => `
   <a rel="up" aria-label="${ariaLabel}" tabindex="0">
   ${upLinkImage(label, libraryIcon)}
     <span class="setting-text up">${label}</span>
@@ -146,7 +150,7 @@ export interface UpLinkConfig {
   url?: URL;
   label?: string;
   ariaLabel?: string;
-  libraryIcon?: string;
+  libraryIcon?: URL;
 }
 
 export interface IFrameNavigatorConfig {
@@ -789,7 +793,7 @@ export default class IFrameNavigator implements Navigator {
       if (this.upLinkConfig && this.upLinkConfig.url) {
         const upLabel = this.upLinkConfig.label || "";
         const upAriaLabel = this.upLinkConfig.ariaLabel || upLabel;
-        const upLibraryIcon = this.upLinkConfig.libraryIcon || "";
+        const upLibraryIcon = this.upLinkConfig.libraryIcon?.href || "";
         const upHTML = upLinkTemplate(upLabel, upAriaLabel, upLibraryIcon);
         const upParent: HTMLLIElement = document.createElement("li");
         upParent.classList.add("uplink-wrapper");

--- a/test/IFrameNavigatorTests.ts
+++ b/test/IFrameNavigatorTests.ts
@@ -657,7 +657,7 @@ describe("IFrameNavigator", () => {
       });
     });
 
-    it("should show the default SVG logo when custom LibraryIcon is not passed in", async () => {
+    it("should show the default SVG logo when custom LibraryIcon is an empty string", async () => {
       (navigator as IFrameNavigator) = await IFrameNavigator.create({
         element,
         manifestUrl: new URL("http://example.com/manifest.json"),
@@ -677,6 +677,8 @@ describe("IFrameNavigator", () => {
           url: new URL("http://up.com"),
           label: "Up Text",
           ariaLabel: "Up Aria Text",
+          // @ts-ignore
+          libraryIcon: "",
         },
       });
 
@@ -746,6 +748,7 @@ describe("IFrameNavigator", () => {
           url: new URL("http://up.com"),
           label: "Up Text",
           ariaLabel: "Up Aria Text",
+          libraryIcon: new URL("http://example.com/test.png"),
         },
       });
 
@@ -773,13 +776,15 @@ describe("IFrameNavigator", () => {
         upLink: {
           url: new URL("http://up.com"),
           label: "Up Text",
+          ariaLabel: "Up Text Aria",
+          libraryIcon: new URL("http://up.com/example.png"),
         },
       });
 
       upLink = element.querySelector("a[rel=up]") as HTMLAnchorElement;
       expect(upLink).to.be.ok;
       expect(upLink.innerHTML).to.contain("Up Text");
-      expect(upLink.getAttribute("aria-label")).to.equal("Up Text");
+      expect(upLink.getAttribute("aria-label")).to.equal("Up Text Aria");
     });
 
     it("should enable the fullscreen mode if supported and configured", async () => {

--- a/test/IFrameNavigatorTests.ts
+++ b/test/IFrameNavigatorTests.ts
@@ -690,6 +690,36 @@ describe("IFrameNavigator", () => {
       expect(noCustomIcon.src).not.to.be.ok;
     });
 
+    it("should have a link to upLink URL", async () => {
+      (navigator as IFrameNavigator) = await IFrameNavigator.create({
+        element,
+        manifestUrl: new URL("http://example.com/manifest.json"),
+        store,
+        settings,
+        annotator,
+        publisher,
+        serif,
+        sans,
+        day,
+        sepia,
+        night,
+        paginator,
+        scroller,
+        eventHandler,
+        upLink: {
+          url: new URL("http://up.com"),
+          label: "Up Text",
+          ariaLabel: "Up Aria Text",
+          libraryIcon: new URL("http://example.com/test.png"),
+        },
+      });
+
+      const customIcon = element.querySelector(
+        ".uplink-wrapper > a:nth-child(1)"
+      ) as HTMLAnchorElement;
+      expect(customIcon.href).to.contain("http://up.com/");
+    });
+
     it("should show the custom uplink image when LibraryIcon is passed in", async () => {
       (navigator as IFrameNavigator) = await IFrameNavigator.create({
         element,

--- a/test/IFrameNavigatorTests.ts
+++ b/test/IFrameNavigatorTests.ts
@@ -657,6 +657,71 @@ describe("IFrameNavigator", () => {
       });
     });
 
+    it("should show the default SVG logo when custom LibraryIcon is not passed in", async () => {
+      (navigator as IFrameNavigator) = await IFrameNavigator.create({
+        element,
+        manifestUrl: new URL("http://example.com/manifest.json"),
+        store,
+        settings,
+        annotator,
+        publisher,
+        serif,
+        sans,
+        day,
+        sepia,
+        night,
+        paginator,
+        scroller,
+        eventHandler,
+        upLink: {
+          url: new URL("http://up.com"),
+          label: "Up Text",
+          ariaLabel: "Up Aria Text",
+        },
+      });
+
+      const defaultIcon = element.querySelector(".icon") as SVGElement;
+      expect(defaultIcon.getAttribute("aria-labelledby")).to.equal("up-label");
+
+      const noCustomIcon = element.querySelector(".icon") as HTMLImageElement;
+      // A custom icon isn't shown if it's not configured.
+      expect(noCustomIcon.src).not.to.be.ok;
+    });
+
+    it("should show the custom uplink image when LibraryIcon is passed in", async () => {
+      (navigator as IFrameNavigator) = await IFrameNavigator.create({
+        element,
+        manifestUrl: new URL("http://example.com/manifest.json"),
+        store,
+        settings,
+        annotator,
+        publisher,
+        serif,
+        sans,
+        day,
+        sepia,
+        night,
+        paginator,
+        scroller,
+        eventHandler,
+        upLink: {
+          url: new URL("http://up.com"),
+          label: "Up Text",
+          ariaLabel: "Up Aria Text",
+          libraryIcon: new URL("http://example.com/test.png"),
+        },
+      });
+
+      const customIcon = element.querySelector(".icon") as HTMLImageElement;
+      expect(customIcon.src).to.contain("http://example.com/test.png");
+      expect(customIcon.getAttribute("title")).to.equal("Up Text");
+
+      /* custom icon doesn't have aria-labelledby as it uses the title attribute instead, aria-labelledby should only be present for SVG version of icon*/
+      const defaultIcon = element.querySelector(".icon") as SVGElement;
+
+      expect(defaultIcon.getAttribute("aria-labelledby")).not.to.be.ok;
+    });
+
     it("should show the up link", async () => {
       const noUpLink = element.querySelector("a[rel=up]");
       // The up link isn't shown if it's not configured.

--- a/test/IFrameNavigatorTests.ts
+++ b/test/IFrameNavigatorTests.ts
@@ -657,7 +657,7 @@ describe("IFrameNavigator", () => {
       });
     });
 
-    it("should show the default SVG logo when custom LibraryIcon is an empty string", async () => {
+    it("should show the default SVG logo when custom LibraryIcon is an ommitted from upLink", async () => {
       (navigator as IFrameNavigator) = await IFrameNavigator.create({
         element,
         manifestUrl: new URL("http://example.com/manifest.json"),
@@ -677,8 +677,6 @@ describe("IFrameNavigator", () => {
           url: new URL("http://up.com"),
           label: "Up Text",
           ariaLabel: "Up Aria Text",
-          // @ts-ignore
-          libraryIcon: "",
         },
       });
 

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -99,8 +99,7 @@
               var upLink = {
                 url: new URL("https://github.com/NYPL-Simplified/webpub-viewer"),
                 label: "Return to Digital Research Books Beta",
-                ariaLabel: "Return to Digital Research Books  Beta",
-                libraryIcon: new URL("https://www.nypl.org/sites/default/files/images/av/news_2009_11_06_logo.jpeg")
+                ariaLabel: "Return to Digital Research Books  Beta"
               };
 
               BookSettings.create({

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -100,6 +100,7 @@
                 url: new URL("https://github.com/NYPL-Simplified/webpub-viewer"),
                 label: "Return to Digital Research Books Beta",
                 ariaLabel: "Return to Digital Research Books  Beta",
+                libraryIcon: new URL("https://www.nypl.org/sites/default/files/images/av/news_2009_11_06_logo.jpeg")
               };
 
               BookSettings.create({


### PR DESCRIPTION
Currently, the NYPL Logo is hard-coded within the uplink (nav) portion of the webpub-viewer. The uplink already has customizable url, label, and ariaLabel.


This PR updates the webpub-viewer to allow passing in a custom logo (i.e., Open E-Books logo) URL to display in nav. The default icon will be the NYPL icon so this should not be a broken change.