### PR TITLE
Resolve parsing errors for non-XHTML content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.2.1]
+## [0.2.2]
+
 ### Fixes
+
+- Spine and Table of Contents updated to only render XHTML files.
+
+## [0.2.1]
+
+### Fixes
+
 - New epubs no longer download as files instead of displaying
 
 ## [0.2.0]
+
 ### Adds
+
 - Adds Access Control for epubs
 - Preloads epubs and stores them in browser storage
 - If an encrypted epub is loaded without appropriate crypto functions, an error page appears.
 
 ### Bugfixes
+
 - Only show page navigation buttons when Table of Contents is inactive/not visible.
 - Hide page navigation buttons when Table of Contents is active/visible.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "library-simplified-webpub-viewer",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "NYPL Digital",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/NYPL-simplified/webpub-viewer",

--- a/src/Manifest.ts
+++ b/src/Manifest.ts
@@ -215,13 +215,22 @@ export default class Manifest {
     const emptySpine: string[] = [];
 
     return (OPFPackage?.package?.manifest?.item || emptySpine).reduce(
-      (acc: any, chapter: { "@attributes": { href: string; id: string } }) => {
+      (
+        acc: any,
+        chapter: {
+          "@attributes": { href: string; id: string; "media-type": string };
+        }
+      ) => {
         const href = chapter["@attributes"]["href"];
-        acc.push({
-          href: href,
-          title: chapter["@attributes"]["id"],
-          localStorageKey: href,
-        });
+
+        if (chapter["@attributes"]["media-type"] == "application/xhtml+xml") {
+          acc.push({
+            href: href,
+            title: chapter["@attributes"]["id"],
+            localStorageKey: href,
+          });
+        }
+
         return acc;
       },
       []
@@ -246,12 +255,13 @@ export default class Manifest {
         )[0]["@attributes"];
         const href = current["href"];
         const mediaType = current["media-type"];
-
-        acc.push({
-          type: mediaType,
-          localStorageKey: href,
-          href: href,
-        });
+        if (mediaType === "application/xhtml+xml") {
+          acc.push({
+            type: mediaType,
+            localStorageKey: href,
+            href: href,
+          });
+        }
         return acc;
       },
       []

--- a/test/ManifestTests.ts
+++ b/test/ManifestTests.ts
@@ -583,7 +583,7 @@ describe(".opf Exploded EPub Manifest", () => {
     });
 
     it("should store links", () => {
-      expect(manifest.links.length).to.equal(13);
+      expect(manifest.links.length).to.equal(8);
       expect(manifest.links[0].href).to.equal("titlepage.xhtml");
     });
 
@@ -603,7 +603,7 @@ describe(".opf Exploded EPub Manifest", () => {
     });
 
     it("should store toc", () => {
-      expect(manifest.toc.length).to.equal(13);
+      expect(manifest.toc.length).to.equal(8);
       expect(manifest.toc[0].title).to.equal("titlepage");
     });
 


### PR DESCRIPTION
- Webpub viewer should only render XHTML content otherwise there are parsing errors and certain content doesn't render properly in the webpub viewer. This PR updates it so that the spine and TOC only contain content with the MediaType of XHTML and therefore only XHTML files are rendered within the viewer.
