### PR TITLE
Pre-loading screen and async book chapter loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## UNRELEASED
+## [0.2.5]
 ### Adds 
 - Prettier to format code
+
+### Fixes
+- TOC now supports both Epub2 (ncx) and Epub3 TOCs 
+- Loading indicator appears before initial page load
 
 ## [0.2.4]
 ### Adds

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "library-simplified-webpub-viewer",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": "NYPL Digital",
   "description": "A viewer application for EPUB files.",
   "repository": "https://github.com/NYPL-simplified/webpub-viewer",

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -117,7 +117,6 @@ export async function embedCssAssets(
     // resolve to absolute url
     const styleUrl = new URL(relativeUrl, resourcePath);
     const resource = await store.getBookData(styleUrl.href);
-
     let cssUrl;
     if (encryption && decryptor && encryption.isEncrypted(styleUrl.href)) {
       cssUrl = await encryption.getDecryptedUrl(resource.data, decryptor);


### PR DESCRIPTION
this PR does two things:  
1) Fetches all the book resources at once, rather than fetching them one at a time
2) Puts the loading spinner while resources are fetching.  (The delay is an old artifact, do you think it is a good idea to show the spinner right away?) 

I tried it with a few books, but please try it with a few more to help me verify that this all actually works!  