### PR TITLE
Add New Security Provisioning Script

### DIFF
--- a/.ebextensions/00_nypl_provisioning.config
+++ b/.ebextensions/00_nypl_provisioning.config
@@ -10,6 +10,6 @@ files:
       if [[ -a $file ]]; then
         echo "installed"
       else
-        curl https://nypl-provisioning.s3.amazonaws.com/provision-yumbased-linux.sh | bash
+        curl https://nypl-provisioning.s3.amazonaws.com/provision-yumbased-linux_eb.sh | bash
       fi
     encoding: plain

--- a/.ebextensions/00_nypl_provisioning.config
+++ b/.ebextensions/00_nypl_provisioning.config
@@ -1,0 +1,15 @@
+files:
+  "/opt/elasticbeanstalk/hooks/appdeploy/pre/07_nypl_provsion.sh":
+    mode: "000755"
+    owner: ec2-user
+    group: ec2-user
+    content: |
+      #!/usr/bin/env bash
+      . /opt/elasticbeanstalk/support/envvars
+           file=/var/tmp/provisioned
+      if [[ -a $file ]]; then
+        echo "installed"
+      else
+        curl https://nypl-provisioning.s3.amazonaws.com/provision-yumbased-linux.sh | bash
+      fi
+    encoding: plain


### PR DESCRIPTION
* Adds a script via .ebextensions to install NYPL IT's security and OS update suite

Once merged, can be deployed to the nypl-sandbox account (ResearchNow-WebPub-Dev) for testing.
